### PR TITLE
Pass devices to controllers from evolver

### DIFF
--- a/evolver/controller/interface.py
+++ b/evolver/controller/interface.py
@@ -1,27 +1,13 @@
 from abc import ABC, abstractmethod
 
-from evolver.base import BaseConfig, ConfigDescriptor
+from evolver.base import BaseConfig
 
 
 class Controller(ABC):
-    """
-        Base interface class for all control implementations.
-
-        Attributes:
-            devices (:obj:`dict` of :obj:`Device`, :obj:`dict` of :obj:`ConfigDescriptor`): Dictionary of devices to
-                control.
-    """
+    """ Base interface class for all control implementations. """
 
     class Config(BaseConfig):
-        devices: dict
-
-    def __init__(self, devices: dict):
-        self.devices = devices
-
-        # Instantiate objects from config descriptors.
-        for device in self.devices:
-            if isinstance(device, ConfigDescriptor):
-                self.devices[device] = device.create()
+        ...
 
     def pre_control(self, *args, **kwargs):
         """ Hook for customization pre-control execution, see self.run().

--- a/evolver/controller/interface.py
+++ b/evolver/controller/interface.py
@@ -1,14 +1,27 @@
 from abc import ABC, abstractmethod
 
-from evolver.base import BaseConfig
+from evolver.base import BaseConfig, ConfigDescriptor
 
 
 class Controller(ABC):
-    class Config(BaseConfig):
-        ...
+    """
+        Base interface class for all control implementations.
 
-    def __init__(self, evolver, config: Config = None):
-        self.config = config or self.Config()
+        Attributes:
+            devices (:obj:`dict` of :obj:`Device`, :obj:`dict` of :obj:`ConfigDescriptor`): Dictionary of devices to
+                control.
+    """
+
+    class Config(BaseConfig):
+        devices: dict
+
+    def __init__(self, devices: dict):
+        self.devices = devices
+
+        # Instantiate objects from config descriptors.
+        for device in self.devices:
+            if isinstance(device, ConfigDescriptor):
+                self.devices[device] = device.create()
 
     def pre_control(self, *args, **kwargs):
         """ Hook for customization pre-control execution, see self.run().

--- a/evolver/tests/test_controller.py
+++ b/evolver/tests/test_controller.py
@@ -16,4 +16,4 @@ class TestController(Controller):
 
 class TestControllerInterface:
     def test_hooks(self):
-        assert TestController(evolver=None).run() == "pre control data, control data, post control data"
+        assert TestController().run() == "pre control data, control data, post control data"


### PR DESCRIPTION
Resolves #54 

~Actually, this totally doesn't work either as the design that @amitschang you came up with to name the devices explicitly in the config, is better, which means that this just doesn't go in the interface at all, but then neither should the ``evolver``. So this PR should really only rip that out rather than replace it.~