### PR TITLE
Add chemostat controller implementation

### DIFF
--- a/evolver/controller/interface.py
+++ b/evolver/controller/interface.py
@@ -9,6 +9,7 @@ class Controller(ABC):
 
     def __init__(self, evolver, config: Config = None):
         self.config = config or self.Config()
+        self.evolver = evolver
 
     def pre_control(self, *args, **kwargs):
         """ Hook for customization pre-control execution, see self.run().

--- a/evolver/controller/standard/__init__.py
+++ b/evolver/controller/standard/__init__.py
@@ -1,0 +1,3 @@
+from .chemostat import Chemostat
+
+__all__ = ['Chemostat']

--- a/evolver/controller/standard/chemostat.py
+++ b/evolver/controller/standard/chemostat.py
@@ -25,10 +25,20 @@ class Chemostat(Controller):
         # come from history similarly
         self.start_time = time.time()
 
+    @property
+    def od(self):
+        return self.evolver.hardware.get(self.config.od_sensor)
+
+    @property
+    def pump(self):
+        return self.evolver.hardware.get(self.config.pump)
+
+    @property
+    def stir(self):
+        return self.evolver.hardware.get(self.config.stirrer)
+
     def control(self, *args, **kwargs):
-        od_values = self.evolver.hardware.get(self.config.od_sensor).get()
-        pump = self.evolver.hardware.get(self.config.pump)
-        stir = self.evolver.hardware.get(self.config.stirrer)
+        od_values = self.od.get()
         elapsed_time = time.time() - self.start_time
 
         if set(self.config.vials or []) - set(od_values):
@@ -52,5 +62,5 @@ class Chemostat(Controller):
             # Inputs assume the relevant device has its calibration and takes
             # the target real value. These may be missing spec, for example does
             # pump need bolus value also?
-            pump.set(pump.Input(vial=vial, flow_rate=self.config.flow_rate))
-            stir.set(stir.Input(vial=vial, stir_rate=self.config.stir_rate))
+            self.pump.set(self.pump.Input(vial=vial, flow_rate=self.config.flow_rate))
+            self.stir.set(self.stir.Input(vial=vial, stir_rate=self.config.stir_rate))

--- a/evolver/controller/standard/chemostat.py
+++ b/evolver/controller/standard/chemostat.py
@@ -1,0 +1,53 @@
+import time
+from pydantic import Field
+from collections import defaultdict, deque
+from evolver.controller.interface import Controller
+from evolver.hardware.interface import VialConfigBaseModel
+
+
+class Chemostat(Controller):
+    class Config(VialConfigBaseModel):
+        od_sensor: str = Field(description="name of OD sensor to use")
+        pump: str = Field(description="name of pump device to use")
+        stirrer: str = Field(description="name of stirrer device to use")
+        window: int = Field(7, description="number of OD measurements to collect prior to start")
+        start_od: float = Field(0, description="OD at which to start chemostat dilutions")
+        start_time: int = Field(0, description="Time (in hours) after which to start dilutions")
+        flow_rate: float = Field(0, description="Flow rate for dilutions")
+        stir_rate: float = Field(8, description="Stir rate")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # buffer could come from history as well
+        self.od_buffer = defaultdict(lambda: deque(maxlen=self.config.window))
+        # start_time is something we might actually want to be a property of
+        # evolver, in case of interrupt it has a chance of continuing - but can
+        # come from history similarly
+        self.start_time = time.time()
+
+    def control(self):
+        od_val = self.evolver.hardware.get(self.config.od_sensor).get()
+        pump = self.evolver.hardware.get(self.config.pump)
+        stir = self.evolver.hardware.get(self.config.stirrer)
+        elapsed_time = time.time() - self.start_time
+
+        for vial, val in od_val.items():
+            if self.config.vials and vial not in self.config.vials:
+                continue
+
+            # Load the rotating window buffer with latest value and only proceed
+            # with dilutions if both we have the full window loaded and it has
+            # been configured time since start
+            self.od_buffer[vial].append(od_val[vial].density)
+            if len(self.od_buffer[vial]) < self.config.window or elapsed_time < self.config.start_time * 3600:
+                continue
+
+            od_mean = sum(self.od_buffer[vial]) / self.config.window
+            if self.config.start_od > od_mean:
+                continue
+
+            # Inputs assume the relevant device has its calibration and takes
+            # the target real value. These may be missing spec, for example does
+            # pump need bolus value also?
+            pump.set(pump.Input(vial=vial, flow_rate=self.config.flow_rate))
+            stir.set(stir.Input(vial=vial, stir_rate=self.config.stir_rate))

--- a/evolver/controller/standard/chemostat.py
+++ b/evolver/controller/standard/chemostat.py
@@ -11,8 +11,8 @@ class Chemostat(Controller):
         pump: str = Field(description="name of pump device to use")
         stirrer: str = Field(description="name of stirrer device to use")
         window: int = Field(7, description="number of OD measurements to collect prior to start")
-        start_od: float = Field(0, description="OD at which to start chemostat dilutions")
-        start_time: int = Field(0, description="Time (in hours) after which to start dilutions")
+        min_od: float = Field(0, description="OD at which to start chemostat dilutions")
+        start_delay: int = Field(0, description="Time (in hours) after which to start dilutions")
         flow_rate: float = Field(0, description="Flow rate for dilutions")
         stir_rate: float = Field(8, description="Stir rate")
 
@@ -26,24 +26,27 @@ class Chemostat(Controller):
         self.start_time = time.time()
 
     def control(self, *args, **kwargs):
-        od_val = self.evolver.hardware.get(self.config.od_sensor).get()
+        od_values = self.evolver.hardware.get(self.config.od_sensor).get()
         pump = self.evolver.hardware.get(self.config.pump)
         stir = self.evolver.hardware.get(self.config.stirrer)
         elapsed_time = time.time() - self.start_time
 
-        for vial, val in od_val.items():
+        if set(self.config.vials or []) - set(od_values):
+            raise ValueError(f'missing vials: I want: {self.config.vials}, OD provides: {od_values.keys()}')
+
+        for vial, od_value in od_values.items():
             if self.config.vials and vial not in self.config.vials:
                 continue
 
             # Load the rotating window buffer with latest value and only proceed
             # with dilutions if both we have the full window loaded and it has
             # been configured time since start
-            self.od_buffer[vial].append(od_val[vial].density)
-            if len(self.od_buffer[vial]) < self.config.window or elapsed_time < self.config.start_time * 3600:
+            self.od_buffer[vial].append(od_value.density)
+            if len(self.od_buffer[vial]) < self.config.window or elapsed_time < self.config.start_delay * 3600:
                 continue
 
             od_mean = sum(self.od_buffer[vial]) / self.config.window
-            if self.config.start_od > od_mean:
+            if self.config.min_od > od_mean:
                 continue
 
             # Inputs assume the relevant device has its calibration and takes

--- a/evolver/controller/standard/chemostat.py
+++ b/evolver/controller/standard/chemostat.py
@@ -25,7 +25,7 @@ class Chemostat(Controller):
         # come from history similarly
         self.start_time = time.time()
 
-    def control(self):
+    def control(self, *args, **kwargs):
         od_val = self.evolver.hardware.get(self.config.od_sensor).get()
         pump = self.evolver.hardware.get(self.config.pump)
         stir = self.evolver.hardware.get(self.config.stirrer)

--- a/evolver/controller/standard/tests/test_chemostat.py
+++ b/evolver/controller/standard/tests/test_chemostat.py
@@ -25,15 +25,15 @@ def mock_hardware():
 
 
 @pytest.mark.parametrize('window', [4,7])
-@pytest.mark.parametrize('start_od', [0, 1])
+@pytest.mark.parametrize('min_od', [0, 1])
 @pytest.mark.parametrize('stir_rate,flow_rate', [(1,2), (9.9, 10.1)])
-def test_chemostat_standard_operation(mock_hardware, window, start_od, stir_rate, flow_rate):
+def test_chemostat_standard_operation(mock_hardware, window, min_od, stir_rate, flow_rate):
     config = Chemostat.Config(
         od_sensor='od',
         pump='pump',
         stirrer='stirrer',
         window=window,
-        start_od=start_od,
+        min_od=min_od,
         stir_rate=stir_rate,
         flow_rate=flow_rate,
     )
@@ -51,7 +51,7 @@ def test_chemostat_standard_operation(mock_hardware, window, start_od, stir_rate
 
     # After window is complete, we expect to have started dilutions, where we
     # expect commands to have been sent to pump and stir
-    if start_od == 0:
+    if min_od == 0:
         assert pump.inputs == [{'vial': 0, 'flow_rate': flow_rate}, {'vial': 1, 'flow_rate': flow_rate}]
         assert stir.inputs == [{'vial': 0, 'stir_rate': stir_rate}, {'vial': 1, 'stir_rate': stir_rate}]
     else:

--- a/evolver/controller/standard/tests/test_chemostat.py
+++ b/evolver/controller/standard/tests/test_chemostat.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import MagicMock
+from evolver.controller.standard import Chemostat
+from evolver.device import Evolver
+
+
+@pytest.fixture
+def mock_hardware():
+    evolver = Evolver()
+    evolver.hardware = {i: MagicMock() for i in ['od', 'pump', 'stirrer']}
+    evolver.hardware['od'].get.return_value = {0: MagicMock(density=0), 1: MagicMock(density=1)}
+    # setup mock for enabling assert on set values for effectors. Pulls out all
+    # named attributes from the given input and stores in call list upon set
+    def setup_hw_mock(mock):
+        mock.inputs = []
+        mock.Input.side_effect = lambda **a: a
+        mock.set.side_effect = lambda a: mock.inputs.append(a)
+    setup_hw_mock(evolver.hardware['pump'])
+    setup_hw_mock(evolver.hardware['stirrer'])
+    return evolver
+
+
+@pytest.mark.parametrize('window', [4,7])
+@pytest.mark.parametrize('start_od', [0, 1])
+@pytest.mark.parametrize('stir_rate,flow_rate', [(1,2), (9.9, 10.1)])
+def test_chemostat_standard_operation(mock_hardware, window, start_od, stir_rate, flow_rate):
+    config = Chemostat.Config(
+        od_sensor='od',
+        pump='pump',
+        stirrer='stirrer',
+        window=window,
+        start_od=start_od,
+        stir_rate=stir_rate,
+        flow_rate=flow_rate,
+    )
+    c = Chemostat(mock_hardware, config)
+    pump = mock_hardware.hardware['pump']
+    stir = mock_hardware.hardware['stirrer']
+
+    # one less control than window to ensure we have not yet made a set
+    for i in range(window - 1):
+        c.control()
+
+    assert pump.inputs == stir.inputs == []
+    # finish filling the buffer up to window size
+    c.control()
+
+    # After window is complete, we expect to have started dilutions, where we
+    # expect commands to have been sent to pump and stir
+    if start_od == 0:
+        assert pump.inputs == [{'vial': 0, 'flow_rate': flow_rate}, {'vial': 1, 'flow_rate': flow_rate}]
+        assert stir.inputs == [{'vial': 0, 'stir_rate': stir_rate}, {'vial': 1, 'stir_rate': stir_rate}]
+    else:
+        # only vial 1 meets the mean OD requirements
+        assert pump.inputs == [{'vial': 1, 'flow_rate': flow_rate}]
+        assert stir.inputs == [{'vial': 1, 'stir_rate': stir_rate}]


### PR DESCRIPTION
A first version of the chemostat that roughly follows the chemostat in existing dpu (https://github.com/FYNCH-BIO/dpu/blob/master/experiment/template/custom_script.py#L161), of course without the actual hardware to back it up.

This can serve as an anchor for refactoring and its practical impact on a controller.