### PR TITLE
Fix serial is_open check and response exception

### DIFF
--- a/evolver/connection/interface.py
+++ b/evolver/connection/interface.py
@@ -48,7 +48,7 @@ class Connection(BaseInterface):
 
     def is_open(self):
         if hasattr(self.conn, "is_open"):
-            return self.conn.is_open()
+            return self.conn.is_open
 
         return self.conn is not None
 

--- a/evolver/connection/interface.py
+++ b/evolver/connection/interface.py
@@ -48,8 +48,7 @@ class Connection(BaseInterface):
 
     def is_open(self):
         if hasattr(self.conn, "is_open"):
-            return self.conn.is_open
-
+            return self.conn.is_open() if callable(self.conn.is_open) else self.conn.is_open
         return self.conn is not None
 
     def open(self, *args, reuse: bool = settings.CONNECTION_REUSE_POLICY_DEFAULT, **kwargs):

--- a/evolver/serial.py
+++ b/evolver/serial.py
@@ -34,7 +34,7 @@ class EvolverSerialUART(Connection):
     @classmethod
     def _decode_serial_data(cls, response, suffix=CMD.RESP_SUFFIX.value):
         parts = response.split(b',')
-        if resp_suffix := parts.pop() != suffix:
+        if (resp_suffix := parts.pop()) != suffix:
             raise ValueError(f"Incorrect command suffix detected: expected '{suffix}' but got '{resp_suffix}'")
         addrcode = parts[0].decode('utf-8')
         addr, code = addrcode[:-1], addrcode[-1]
@@ -52,8 +52,8 @@ class EvolverSerialUART(Connection):
         response = self.conn.readline()
         try:
             return self._decode_serial_data(response)
-        except Exception:
-            raise ValueError('invalid response')
+        except Exception as exc:
+            raise ValueError(f'invalid response: {exc}') from exc
 
     def communicate(self, cmd: SerialData):
         # need to lock since we do three way comminication and during that term

--- a/evolver/tests/test_serial.py
+++ b/evolver/tests/test_serial.py
@@ -21,6 +21,6 @@ def test_uart_serial(payload):
 
 def test_uart_bad_response_raises(payload):
     with EvolverSerialUARTEmulator() as s:
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match=r".* but got .*badresponse"):
             epayload = payload.model_copy(update=dict(addr='Xyz'))
             s.communicate(epayload)


### PR DESCRIPTION
A couple bug fixes. Turns out pyserial implements `is_open` as a property. The exception for bad response hid the response data since the walrus was assigned a boolean. 