### PR TITLE
Bug in app update config

### DIFF
--- a/evolver/app/tests/test_app.py
+++ b/evolver/app/tests/test_app.py
@@ -32,6 +32,14 @@ class TestApp:
         newconfig = app_client.get('/').json()['config']
         assert newconfig['hardware']['test']['driver'] == 'evolver.hardware.demo.NoOpSensorDriver'
 
+        data = {'history': {'driver': 'evolver.history.HistoryServer'}}
+        response = app_client.post('/', json=data)
+        assert response.status_code == 200
+
+        newconfig = app_client.get('/').json()['config']
+        assert newconfig["history"]["driver"] == 'evolver.history.HistoryServer'
+        assert newconfig['hardware']['test']['driver'] == 'evolver.hardware.demo.NoOpSensorDriver'
+
     def test_evolver_app_control_loop_setup(self, app_client):
         # The context manager ensures that startup event loop is called
         # TODO: check results generated in control() (may require hardware at startup, or forced execution of loop)

--- a/evolver/history.py
+++ b/evolver/history.py
@@ -18,7 +18,7 @@ class History(ABC):
 
 
 class HistoryServer(History):
-    def __init__(self, config = None):
+    def __init__(self, evolver=None, config = None):
         self.history = defaultdict(list)
 
     def put(self, name, data):


### PR DESCRIPTION
The update endpoint expects input as ``EvolverConfig``.
```python
@app.post("/")
async def update_evolver(config: EvolverConfig):
    evolver.update_config(config)
```

This gets validated, but it must be a full/complete model. The existing model has defaults for all such that a partial config can be passed because the others get populated from defaults.

The bug is that update looks like it should only partially update the config, however, it clobbers the existing, which I don't think it should.

The test in this PR expresses this bug. Really, the test(s) should invoke an evolver with non-default config, and then test that config hasn't changed before and after the partial update, e.g., only changing the hardware list.

A solution is to not require a full model be passed to the update endpoint.