### PR TITLE
Add initial OD sensor implementation

### DIFF
--- a/evolver/hardware/standard/od_sensor.py
+++ b/evolver/hardware/standard/od_sensor.py
@@ -1,0 +1,27 @@
+from pydantic import Field
+from evolver.hardware.interface import SensorDriver, VialBaseModel, VialConfigBaseModel
+from evolver.serial import SerialData
+
+
+class ODSensor(SensorDriver):
+    """Optical density sensor driver
+
+    This driver represents a family of sensors for turbidity which are read by
+    integrating a specified number of ADC readings per vial.
+    """
+    class Config(VialConfigBaseModel):
+        addr: str = Field(description="Address of od sensor on serial bus (e.g. od_90)")
+        integrations: int = Field(500, description="on read, request average of this number of ADC reads")
+
+    class Output(VialBaseModel):
+        raw: int
+        od: float = None
+
+    def read(self):
+        self.outputs = {}
+        cmd_data = str(self.config.integrations).encode()
+        cmd = SerialData(addr=self.config.addr, data=[cmd_data], kind='r')
+        with self.evolver.serial as comm:
+            response = comm.communicate(cmd)
+        for vial, raw in enumerate(response.data):
+            self.outputs[vial] = self.Output(vial=vial, raw=raw)

--- a/evolver/hardware/standard/od_sensor.py
+++ b/evolver/hardware/standard/od_sensor.py
@@ -27,8 +27,7 @@ class ODSensor(SensorDriver):
 
     def read(self):
         self.outputs = {}
-        cmd_data = str(self.integrations).encode()
-        cmd = SerialData(addr=self.addr, data=[cmd_data], kind="r")
+        cmd = SerialData(addr=self.addr, data=[str(self.integrations).encode()], kind="r")
         with self.serial as comm:
             response = comm.communicate(cmd)
         for vial, raw in enumerate(response.data):

--- a/evolver/hardware/standard/od_sensor.py
+++ b/evolver/hardware/standard/od_sensor.py
@@ -19,8 +19,8 @@ class ODSensor(SensorDriver):
 
     def read(self):
         self.outputs = {}
-        cmd_data = str(self.config.integrations).encode()
-        cmd = SerialData(addr=self.config.addr, data=[cmd_data], kind='r')
+        cmd_data = str(self.integrations).encode()
+        cmd = SerialData(addr=self.addr, data=[cmd_data], kind='r')
         with self.evolver.serial as comm:
             response = comm.communicate(cmd)
         for vial, raw in enumerate(response.data):

--- a/evolver/hardware/standard/od_sensor.py
+++ b/evolver/hardware/standard/od_sensor.py
@@ -1,5 +1,6 @@
 from pydantic import Field
 
+from evolver.base import ConfigDescriptor
 from evolver.connection.interface import Connection
 from evolver.hardware.interface import SensorDriver, VialBaseModel, VialConfigBaseModel
 from evolver.serial import SerialData
@@ -15,7 +16,7 @@ class ODSensor(SensorDriver):
     class Config(VialConfigBaseModel):
         addr: str = Field(description="Address of od sensor on serial bus (e.g. od_90)")
         integrations: int = Field(500, description="on read, request average of this number of ADC reads")
-        serial_conn: Connection | None = Field(None, description="serial connection, default is that on evolver")
+        serial_conn: Connection | ConfigDescriptor | None = Field(None, description="serial connection, default is that on evolver")
 
     class Output(VialBaseModel):
         raw: int

--- a/evolver/hardware/standard/od_sensor.py
+++ b/evolver/hardware/standard/od_sensor.py
@@ -1,4 +1,5 @@
 from pydantic import Field
+
 from evolver.hardware.interface import SensorDriver, VialBaseModel, VialConfigBaseModel
 from evolver.serial import SerialData
 
@@ -9,19 +10,21 @@ class ODSensor(SensorDriver):
     This driver represents a family of sensors for turbidity which are read by
     integrating a specified number of ADC readings per vial.
     """
+
     class Config(VialConfigBaseModel):
         addr: str = Field(description="Address of od sensor on serial bus (e.g. od_90)")
         integrations: int = Field(500, description="on read, request average of this number of ADC reads")
 
     class Output(VialBaseModel):
         raw: int
-        od: float = None
+        density: float = None
 
     def read(self):
         self.outputs = {}
         cmd_data = str(self.integrations).encode()
-        cmd = SerialData(addr=self.addr, data=[cmd_data], kind='r')
+        cmd = SerialData(addr=self.addr, data=[cmd_data], kind="r")
         with self.evolver.serial as comm:
             response = comm.communicate(cmd)
         for vial, raw in enumerate(response.data):
-            self.outputs[vial] = self.Output(vial=vial, raw=raw)
+            if vial in self.vials:
+                self.outputs[vial] = self.Output(vial=vial, raw=raw)

--- a/evolver/hardware/standard/od_sensor.py
+++ b/evolver/hardware/standard/od_sensor.py
@@ -16,7 +16,9 @@ class ODSensor(SensorDriver):
     class Config(VialConfigBaseModel):
         addr: str = Field(description="Address of od sensor on serial bus (e.g. od_90)")
         integrations: int = Field(500, description="on read, request average of this number of ADC reads")
-        serial_conn: Connection | ConfigDescriptor | None = Field(None, description="serial connection, default is that on evolver")
+        serial_conn: Connection | ConfigDescriptor | None = Field(
+            None, description="serial connection, default is that on evolver"
+        )
 
     class Output(VialBaseModel):
         raw: int

--- a/evolver/hardware/standard/tests/test_od_sensor.py
+++ b/evolver/hardware/standard/tests/test_od_sensor.py
@@ -1,15 +1,18 @@
 import pytest
+
 from evolver.device import Evolver
-from evolver.serial import create_mock_serial
 from evolver.hardware.standard.od_sensor import ODSensor
+from evolver.serial import create_mock_serial
 
 
 @pytest.fixture
 def serial_mock():
-    return create_mock_serial({
-            b'od_90r,500,_!': b'od_90a,123,456,end',
-            b'od_90r,100,_!': b'od_90a,101,102,end',
-        })
+    return create_mock_serial(
+        {
+            b"od_90r,500,_!": b"od_90a,123,456,end",
+            b"od_90r,100,_!": b"od_90a,101,102,end",
+        }
+    )
 
 
 @pytest.fixture
@@ -19,37 +22,43 @@ def evolver(serial_mock):
     return e
 
 
-@pytest.mark.parametrize("integs, expect", [(500, (123, 456)), (100, (101, 102))])
-def test_od_sensor(evolver, integs, expect):
-    od = ODSensor(addr='od_90', integrations=integs, evolver=evolver)
+@pytest.mark.parametrize(
+    "integs, vials, expect",
+    [
+        (500, [0, 1], (123, 456)),
+        (100, [0, 1], (101, 102)),
+        (500, [0], (123, None)),
+        (100, [1], (None, 102)),
+    ],
+)
+def test_od_sensor(evolver, integs, vials, expect):
+    od = ODSensor(addr="od_90", integrations=integs, vials=vials, evolver=evolver)
     od.read()
-    for vial in range(len(expect)):
+    assert set(od.get().keys()) == set(vials)
+    for vial in vials:
         assert od.get()[vial] == ODSensor.Output(vial=vial, raw=expect[vial])
-
 
 
 @pytest.mark.parametrize("integs, expect", [(500, (123, 456)), (100, (101, 102))])
 def test_evolver_hookup(serial_mock, integs, expect):
     config = {
-        'hardware': {
-            'od': {
-                'classinfo': 'evolver.hardware.standard.od_sensor.ODSensor',
-                'config': {
-                    'addr': 'od_90',
-                    'integrations': integs,
-                }
+        "hardware": {
+            "od": {
+                "classinfo": "evolver.hardware.standard.od_sensor.ODSensor",
+                "config": {
+                    "addr": "od_90",
+                    "integrations": integs,
+                },
             }
         }
     }
     evolver = Evolver.create(config)
     evolver.serial = serial_mock
-    assert evolver.state == {'od': {}}
+    assert evolver.state == {"od": {}}
     evolver.loop_once()
     assert evolver.state == {
-        'od': {
+        "od": {
             0: ODSensor.Output(vial=0, raw=expect[0]),
             1: ODSensor.Output(vial=1, raw=expect[1]),
         }
     }
-
-

--- a/evolver/hardware/standard/tests/test_od_sensor.py
+++ b/evolver/hardware/standard/tests/test_od_sensor.py
@@ -1,0 +1,60 @@
+import pytest
+from evolver.device import Evolver, EvolverConfig
+from evolver.serial import PySerialEmulator, EvolverSerialUART
+from evolver.hardware.standard.od_sensor import ODSensor
+
+
+@pytest.fixture
+def serial_mock():
+    class ResponseBackendEmulator(PySerialEmulator):
+        raw_response_map = {
+            b'od_90r,500,_!': b'od_90a,123,456,end',
+            b'od_90r,100,_!': b'od_90a,101,102,end',
+        }
+    class SerialEmulator(EvolverSerialUART):
+        backend = ResponseBackendEmulator
+
+    return SerialEmulator()
+
+
+@pytest.fixture
+def evolver_mock(serial_mock):
+    e = Evolver()
+    e.serial = serial_mock
+    return e
+
+
+@pytest.mark.parametrize("integs, expect", [(500, (123, 456)), (100, (101, 102))])
+def test_od_sensor(evolver_mock, integs, expect):
+    od = ODSensor(evolver_mock, ODSensor.Config(addr='od_90', integrations=integs))
+    od.read()
+    for vial in range(len(expect)):
+        assert od.get()[vial] == ODSensor.Output(vial=vial, raw=expect[vial])
+
+
+
+@pytest.mark.parametrize("integs, expect", [(500, (123, 456)), (100, (101, 102))])
+def test_evolver_hookup(evolver_mock, serial_mock, integs, expect):
+    config = {
+        'hardware': {
+            'od': {
+                'driver': 'evolver.hardware.standard.od_sensor.ODSensor',
+                'config': {
+                    'addr': 'od_90',
+                    'integrations': integs,
+                }
+            }
+        }
+    }
+    evolver_mock.update_config(EvolverConfig.model_validate(config))
+    evolver_mock.serial = serial_mock
+    assert evolver_mock.state == {'od': {}}
+    evolver_mock.loop_once()
+    assert evolver_mock.state == {
+        'od': {
+            0: ODSensor.Output(vial=0, raw=expect[0]),
+            1: ODSensor.Output(vial=1, raw=expect[1]),
+        }
+    }
+
+

--- a/evolver/hardware/standard/tests/test_od_sensor.py
+++ b/evolver/hardware/standard/tests/test_od_sensor.py
@@ -39,6 +39,14 @@ def test_od_sensor(evolver, integs, vials, expect):
         assert od.get()[vial] == ODSensor.Output(vial=vial, raw=expect[vial])
 
 
+def test_od_sensor_pass_serial(serial_mock):
+    with pytest.raises(AttributeError, match="has no attribute 'serial'"):
+        ODSensor(addr="od_90").read()
+    od = ODSensor(addr="od_90", serial_conn=serial_mock)
+    od.read()
+    assert od.get()[0] == ODSensor.Output(vial=0, raw=123)
+
+
 @pytest.mark.parametrize("integs, expect", [(500, (123, 456)), (100, (101, 102))])
 def test_evolver_hookup(serial_mock, integs, expect):
     config = {

--- a/evolver/hardware/standard/tests/test_od_sensor.py
+++ b/evolver/hardware/standard/tests/test_od_sensor.py
@@ -1,32 +1,27 @@
 import pytest
-from evolver.device import Evolver, EvolverConfig
-from evolver.serial import PySerialEmulator, EvolverSerialUART
+from evolver.device import Evolver
+from evolver.serial import create_mock_serial
 from evolver.hardware.standard.od_sensor import ODSensor
 
 
 @pytest.fixture
 def serial_mock():
-    class ResponseBackendEmulator(PySerialEmulator):
-        raw_response_map = {
+    return create_mock_serial({
             b'od_90r,500,_!': b'od_90a,123,456,end',
             b'od_90r,100,_!': b'od_90a,101,102,end',
-        }
-    class SerialEmulator(EvolverSerialUART):
-        backend = ResponseBackendEmulator
-
-    return SerialEmulator()
+        })
 
 
 @pytest.fixture
-def evolver_mock(serial_mock):
+def evolver(serial_mock):
     e = Evolver()
     e.serial = serial_mock
     return e
 
 
 @pytest.mark.parametrize("integs, expect", [(500, (123, 456)), (100, (101, 102))])
-def test_od_sensor(evolver_mock, integs, expect):
-    od = ODSensor(evolver_mock, ODSensor.Config(addr='od_90', integrations=integs))
+def test_od_sensor(evolver, integs, expect):
+    od = ODSensor(addr='od_90', integrations=integs, evolver=evolver)
     od.read()
     for vial in range(len(expect)):
         assert od.get()[vial] == ODSensor.Output(vial=vial, raw=expect[vial])
@@ -34,11 +29,11 @@ def test_od_sensor(evolver_mock, integs, expect):
 
 
 @pytest.mark.parametrize("integs, expect", [(500, (123, 456)), (100, (101, 102))])
-def test_evolver_hookup(evolver_mock, serial_mock, integs, expect):
+def test_evolver_hookup(serial_mock, integs, expect):
     config = {
         'hardware': {
             'od': {
-                'driver': 'evolver.hardware.standard.od_sensor.ODSensor',
+                'classinfo': 'evolver.hardware.standard.od_sensor.ODSensor',
                 'config': {
                     'addr': 'od_90',
                     'integrations': integs,
@@ -46,11 +41,11 @@ def test_evolver_hookup(evolver_mock, serial_mock, integs, expect):
             }
         }
     }
-    evolver_mock.update_config(EvolverConfig.model_validate(config))
-    evolver_mock.serial = serial_mock
-    assert evolver_mock.state == {'od': {}}
-    evolver_mock.loop_once()
-    assert evolver_mock.state == {
+    evolver = Evolver.create(config)
+    evolver.serial = serial_mock
+    assert evolver.state == {'od': {}}
+    evolver.loop_once()
+    assert evolver.state == {
         'od': {
             0: ODSensor.Output(vial=0, raw=expect[0]),
             1: ODSensor.Output(vial=1, raw=expect[1]),

--- a/evolver/hardware/standard/tests/test_od_sensor.py
+++ b/evolver/hardware/standard/tests/test_od_sensor.py
@@ -39,6 +39,14 @@ def test_od_sensor(evolver, integs, vials, expect):
         assert od.get()[vial] == ODSensor.Output(vial=vial, raw=expect[vial])
 
 
+def test_od_sensor_vial_update(evolver):
+    od = ODSensor(addr="od_90", evolver=evolver)
+    od.read()
+    assert set(od.get().keys()) == set([0,1])
+    od.vials = [0]
+    od.read()
+    assert set(od.get().keys()) == set([0])
+
 def test_od_sensor_pass_serial(serial_mock):
     with pytest.raises(AttributeError, match="has no attribute 'serial'"):
         ODSensor(addr="od_90").read()

--- a/evolver/hardware/standard/tests/test_od_sensor.py
+++ b/evolver/hardware/standard/tests/test_od_sensor.py
@@ -42,10 +42,11 @@ def test_od_sensor(evolver, integs, vials, expect):
 def test_od_sensor_vial_update(evolver):
     od = ODSensor(addr="od_90", evolver=evolver)
     od.read()
-    assert set(od.get().keys()) == set([0,1])
+    assert set(od.get().keys()) == set([0, 1])
     od.vials = [0]
     od.read()
     assert set(od.get().keys()) == set([0])
+
 
 def test_od_sensor_pass_serial(serial_mock):
     with pytest.raises(AttributeError, match="has no attribute 'serial'"):

--- a/evolver/serial.py
+++ b/evolver/serial.py
@@ -98,3 +98,15 @@ class PySerialEmulator:
 
 class EvolverSerialUARTEmulator(EvolverSerialUART):
     backend = PySerialEmulator
+
+
+def create_mock_serial(raw_response_map):
+    class ResponseBackendEmulator(PySerialEmulator):
+        pass
+
+    ResponseBackendEmulator.raw_response_map = raw_response_map
+
+    class SerialEmulator(EvolverSerialUART):
+        backend = ResponseBackendEmulator
+
+    return SerialEmulator()

--- a/evolver/serial.py
+++ b/evolver/serial.py
@@ -69,18 +69,24 @@ class EvolverSerialUART(Connection):
 class PySerialEmulator:
     """For testing purposes only!."""
 
+    raw_response_map = {}
+
     @classmethod
     def Serial(cls, *args, **kwargs):
         return cls(*args, **kwargs)
 
     def __init__(self, *args, **kwargs):
         self._data = None
+        self._data_raw = None
 
     def write(self, data):
+        self._data_raw = data
         self._data = EvolverSerialUART._decode_serial_data(data, suffix=EvolverSerialUART.CMD.SEND_SUFFIX.value)
 
     def readline(self):
-        if not self._data or self._data.addr.startswith("X"):
+        if mapped_response := self.raw_response_map.get(self._data_raw):
+            return mapped_response
+        if not self._data or self._data.addr.startswith('X'):
             return b"badresponse"
         data = self._data.model_copy()
         data.kind = "e"

--- a/evolver/serial.py
+++ b/evolver/serial.py
@@ -86,7 +86,7 @@ class PySerialEmulator:
     def readline(self):
         if mapped_response := self.raw_response_map.get(self._data_raw):
             return mapped_response
-        if not self._data or self._data.addr.startswith('X'):
+        if not self._data or self._data.addr.startswith("X"):
             return b"badresponse"
         data = self._data.model_copy()
         data.kind = "e"


### PR DESCRIPTION
Part of https://github.com/ssec-jhu/evolver-ng/issues/22

Adds an OD sensor implementation which corresponds to that on the default evolver box. For now the calibration is left out but this shows clearly where it would fit: in providing a value for "density" field of "Output".

Adding also some shared infrastructure for testing these serial-based devices. Probably more of the test infra could be shared for hardware modules, but leaving it specific to OD here.