### PR TITLE
Refactor usage of creation pattern.

### DIFF
--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -3,10 +3,10 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from evolver import __project__, __version__
 from evolver.base import require_all_fields
 from evolver.device import Evolver, EvolverConfig
 from evolver.settings import app_settings
-from .. import __project__, __version__
 
 
 @asynccontextmanager
@@ -26,7 +26,7 @@ app.state.evolver = None
 
 
 @require_all_fields
-class EvolverConfigWithoutDefaults(EvolverConfig):
+class EvolverConfigWithoutDefaults(Evolver.Config):
     ...
 
 
@@ -49,7 +49,7 @@ async def get_state():
 
 @app.post("/")
 async def update_evolver(config: EvolverConfigWithoutDefaults):
-    app.state.evolver.update_config(config)
+    app.state.evolver = Evolver.create(config)
     app.state.evolver.config.save(app_settings.CONFIG_FILE)
 
 

--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -12,9 +12,10 @@ from evolver.settings import app_settings
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     # Startup:
-    app.state.evolver = Evolver()
     if app_settings.LOAD_FROM_CONFIG_ON_STARTUP:
-        app.state.evolver.update_config(EvolverConfig.load(app_settings.CONFIG_FILE))
+        app.state.evolver.create(Evolver.Config.load(app_settings.CONFIG_FILE))
+    else:
+        app.state.evolver = Evolver.create()
     asyncio.create_task(evolver_async_loop())
     yield
     # Shutdown:

--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 
 from evolver import __project__, __version__
 from evolver.base import require_all_fields
-from evolver.device import Evolver, EvolverConfig
+from evolver.device import Evolver
 from evolver.settings import app_settings
 
 
@@ -34,7 +34,7 @@ class EvolverConfigWithoutDefaults(Evolver.Config):
 @app.get("/")
 async def describe_evolver():
     return {
-        'config': app.state.evolver.config,
+        'config': app.state.evolver.config_model,
         'state': app.state.evolver.state,
         'last_read': app.state.evolver.last_read,
     }
@@ -72,7 +72,7 @@ async def healthz():
 async def evolver_async_loop():
     while True:
         app.state.evolver.loop_once()
-        await asyncio.sleep(app.state.evolver.config.interval)
+        await asyncio.sleep(app.state.evolver.interval)
 
 
 def start():

--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -13,7 +13,7 @@ from evolver.settings import app_settings
 async def lifespan(app: FastAPI):
     # Startup:
     if app_settings.LOAD_FROM_CONFIG_ON_STARTUP:
-        app.state.evolver.create(Evolver.Config.load(app_settings.CONFIG_FILE))
+        app.state.evolver = Evolver.create(Evolver.Config.load(app_settings.CONFIG_FILE))
     else:
         app.state.evolver = Evolver.create()
     asyncio.create_task(evolver_async_loop())
@@ -51,7 +51,7 @@ async def get_state():
 @app.post("/")
 async def update_evolver(config: EvolverConfigWithoutDefaults):
     app.state.evolver = Evolver.create(config)
-    app.state.evolver.config.save(app_settings.CONFIG_FILE)
+    app.state.evolver.config_model.save(app_settings.CONFIG_FILE)
 
 
 @app.get('/schema')

--- a/evolver/app/tests/conftest.py
+++ b/evolver/app/tests/conftest.py
@@ -2,7 +2,7 @@ import pytest
 from fastapi.testclient import TestClient
 
 from evolver.app.main import app
-from evolver.device import EvolverConfig
+from evolver.device import Evolver
 from evolver.settings import app_settings
 
 
@@ -11,7 +11,7 @@ def app_client(tmp_path, monkeypatch):
     monkeypatch.setattr(app_settings, "CONFIG_FILE", tmp_path / app_settings.CONFIG_FILE)
 
     # Create and save a default config file to be read upon app startup.
-    EvolverConfig().save(app_settings.CONFIG_FILE)
+    Evolver.Config().save(app_settings.CONFIG_FILE)
 
     with TestClient(app) as client:
         yield client

--- a/evolver/app/tests/test_app.py
+++ b/evolver/app/tests/test_app.py
@@ -5,9 +5,9 @@ from fastapi.openapi.utils import get_openapi
 from fastapi.testclient import TestClient
 
 from evolver import __version__
-from evolver.settings import app_settings
-from evolver.device import EvolverConfig, HardwareDriverDescriptor
 from evolver.app.main import app, EvolverConfigWithoutDefaults
+from evolver.settings import app_settings
+from evolver.device import Evolver, EvolverConfig, HardwareDriverDescriptor
 
 
 class TestApp:
@@ -33,12 +33,12 @@ class TestApp:
         assert sorted(response.json().keys()) == ['config', 'last_read', 'state']
 
     def test_EvolverConfigWithoutDefaults(self):
-        EvolverConfigWithoutDefaults.model_validate(EvolverConfig().model_dump())
-        EvolverConfigWithoutDefaults.model_validate_json(EvolverConfig().model_dump_json())
+        EvolverConfigWithoutDefaults.model_validate(Evolver.Config().model_dump())
+        EvolverConfigWithoutDefaults.model_validate_json(Evolver.Config().model_dump_json())
 
     def test_evolver_update_config_endpoint(self, app_client):
         assert app_settings.CONFIG_FILE.exists()  # Note: app_client generates an default config and saves to file.
-        data = {'hardware': {'test': {'driver': 'evolver.hardware.demo.NoOpSensorDriver'}}}
+        data = {'hardware': {'test': {'classinfo': 'evolver.hardware.demo.NoOpSensorDriver'}}}
         response = app_client.post('/', json=data)
         # all config fields are required so the above post failed with an Unprocessable Entity error.
         assert response.status_code == 422
@@ -46,20 +46,26 @@ class TestApp:
         for content in contents["detail"]:
             assert content["msg"] == "Field required"
 
-        new_data = EvolverConfig().copy(update=data)
+        new_data = Evolver.Config().copy(update=data)
         response = app_client.post('/', data=new_data.model_dump_json())
         assert response.status_code == 200
         newconfig = app_client.get('/').json()['config']
-        assert newconfig['hardware']['test']['driver'] == 'evolver.hardware.demo.NoOpSensorDriver'
+        assert newconfig['hardware']['test']['classinfo'] == 'evolver.hardware.demo.NoOpSensorDriver'
         # check we wrote out a file
         with open(app_settings.CONFIG_FILE) as f:
             saved = yaml.safe_load(f)
-        assert saved['hardware']['test']['driver'] == 'evolver.hardware.demo.NoOpSensorDriver'
+        assert saved['hardware']['test']['classinfo'] == 'evolver.hardware.demo.NoOpSensorDriver'
 
     def test_evolver_app_control_loop_setup(self, app_client):
         # TODO: check results generated in control() (may require hardware at startup, or forced execution of loop)
         response = app_client.get('/')
         assert response.status_code == 200
+
+    def test_schema_endpoint(self, app_client):
+        response = app_client.get('/schema')
+        assert response.status_code == 200
+        # There's not much in the default config yet, this will change in future PRs.
+        assert json.loads(response.content) == dict(hardware=[], controllers=[])
 
 
 def test_app_load_file(app_client):
@@ -70,3 +76,5 @@ def test_app_load_file(app_client):
     app.state.evolver.update_config(EvolverConfig.load(app_settings.CONFIG_FILE))
     client = TestClient(app)
     client.get('/').json()['config']['hardware']['file_test']['driver'] == 'evolver.hardware.demo.NoOpSensorDriver'
+    response = app_client.get('/')
+    assert response.status_code == 200

--- a/evolver/base.py
+++ b/evolver/base.py
@@ -1,6 +1,9 @@
 from abc import ABC
+from collections import defaultdict
+import json
 import logging
 from pathlib import Path
+from typing import Annotated, Any, Dict
 
 import pydantic
 import pydantic_core
@@ -33,8 +36,106 @@ def require_all_fields(cls):
     return cls
 
 
-class BaseConfig(pydantic.BaseModel):
-    name: str = None
+# pydantics import string alone does not generate a schema, which breaks openapi
+# docs. We wrap it to set schema explicitly.
+ImportString = Annotated[
+    pydantic.ImportString, pydantic.WithJsonSchema({'type': 'string', 'description': 'fully qualified class name'})
+]
+
+
+class _BaseConfig(pydantic.BaseModel):
+    model_config = pydantic.ConfigDict(extra="ignore",
+                                       from_attributes=True)
+
+    @classmethod
+    def model_validate(cls, obj, *, strict=None, from_attributes=None, context=None):
+        """ Effectively the same as pydantic.BaseModel.model_validate() except that it automatically handles json, and
+            conversion from instances of ``BaseConfig`` and ``BaseInterface`
+        """
+        if obj is None:
+            return cls()
+        elif isinstance(obj, (str,  bytes, bytearray)):
+            return cls.model_validate_json(obj, strict=strict, context=context)
+        elif isinstance(obj, ConfigDescriptor):
+            return super().model_validate(obj.config, strict=strict, from_attributes=from_attributes, context=context)
+        elif isinstance(obj, BaseInterface):
+            return super().model_validate(obj.config,  # Objects are responsible for their own conversion to config.
+                                          strict=strict,
+                                          from_attributes=from_attributes,
+                                          context=context)
+        return super().model_validate(obj, strict=strict, from_attributes=from_attributes, context=context)
+
+
+class BaseConfig(_BaseConfig):
+    name: str | None = None
+
+
+class ConfigDescriptor(_BaseConfig):
+    classinfo: ImportString
+    config: dict = {}
+
+    @classmethod
+    def model_validate(cls, obj, *args, **kwargs):
+        """ Effectively the same as pydantic.BaseModel.model_validate() except that it automatically handles conversion
+            from instances of ``BaseConfig`` and ``BaseInterface``.
+        """
+
+        # Note: ``ConfigDescriptor.config`` is an ordinary dict, without type mappings between keys and values, i.e.,
+        # unlike pydantic model fields. Any nested ``ConfigDescriptor`` in config, when converted to a dict using
+        # ``model_dump()`` will have their classinfo keys remain as their imported classes rather than a fqn str.
+        # The issue with these no longer being models is that ``classinfo`` will just be a normal key and not an
+        # ``ImportString``. Subsequent serialization will not be possible as it doesn't go via
+        # ``ImportString._Serialize()``. To address this, we convert to json and then back to a dict such that
+        # ``classinfo`` has been correctly serialized. This is not ideal, nor performant, though the latter is not an
+        # issue for this code base.
+        # TODO: Rethink ConfigDescriptor.config type, as an ordinary dict doesn't ensure that its contents is
+        #  serializable. The very point of the pydantic framework is to solve this issue.
+
+        if isinstance(obj, type) and issubclass(obj, BaseInterface):
+            return super().model_validate(dict(classinfo=obj.fqn(), config=json.loads(obj.Config().model_dump_json())),
+                                          *args,
+                                          **kwargs)
+        elif isinstance(obj, BaseConfig) and (classinfo := obj.__pydantic_parent_namespace__.get("__qualname__")):
+            return super().model_validate(dict(classinfo=f"{obj.__module__}.{classinfo}",
+                                               config=json.loads(obj.model_dump_json())),
+                                          *args,
+                                          **kwargs)
+        elif isinstance(obj, BaseInterface):
+            return super().model_validate(dict(classinfo=obj.classinfo,
+                                               config=json.loads(obj.config_json)), *args, **kwargs)
+        return super().model_validate(obj, *args, **kwargs)
+
+    def create(self,
+               update: Dict[str, Any] | None = defaultdict(),
+               non_config_kwargs: Dict[str, Any] | None = defaultdict(),
+               **kwargs):
+        """ Create an instance of classinfo from a config.
+
+            Args:
+                update (:obj:`dict`): Key-value pairs used to override contents of ``self.config``. These get validated.
+                non_config_kwargs (:obj:`dict`): Key-value pairs passed to ``classinfo`` upon instantiation. These are
+                                                 not validated.
+                **kwargs: Synonymous with ``update``. Values here take precedence over any in update, i.e., ``config``
+                          is updated using ``update`` first and then ``kwargs``, thus ``kwargs`` will clobber keys also
+                          present in ``update``.
+        """
+        # Update config from kwargs.
+        if update or kwargs:
+            config = self.config.copy()
+            config.update(update)
+            config.update(kwargs)
+        else:
+            config = self.config
+
+        # Instantiate classinfo.Config.
+        # Note: We directly create a ``Config`` rather than just return ``self.classinfo.create(config)``:
+        # 1) for perf (since ``self.classinfo.create()`` will try to turn this in to a ``ConfigDescriptor``).
+        # 2) ``self.config`` must a be a dict representing ``self.Classinfo.Config`` and NOT a dict representing a
+        #    ``ConfigDescriptor`` (which ``self.classinfo.create()`` allows).
+        config = self.classinfo.Config.model_validate(config)  # Note: we don't pass self due to update from kwargs.
+
+        # Return an instance of classinfo.
+        return self.classinfo(**config.model_dump(), **non_config_kwargs)
 
     @classmethod
     def load(cls, file_path: Path, encoding: str | None = None):
@@ -55,29 +156,57 @@ class BaseInterface(ABC):
         ...
 
     @classmethod
-    def create(cls, config=None):
+    def create(cls, config: ConfigDescriptor | dict | str | None = None):
         """ Create an instance from a config. """
-        if config is None:
-            config = cls.Config()
-        elif isinstance(config, str):
-            config = cls.Config.model_validate_json(config)
-        elif isinstance(config, ConfigDescriptor):
-            if not issubclass(cls, config.classinfo):
-                raise TypeError(f"The given {ConfigDescriptor.__name__} for '{config.classinfo}' is not compatible "
+
+        def validate_descriptor(descriptor: ConfigDescriptor):
+            if not issubclass(cls, descriptor.classinfo):
+                raise TypeError(f"The given {ConfigDescriptor.__name__} for '{descriptor.classinfo}' is not compatible "
                                 f"with this class '{cls.__qualname__}'")
+            return cls.Config.model_validate(descriptor, context=dict(extra="forbid"))
 
-            config = cls.Config.model_validate(config.config)
+        # We first try to create a valid Config instance and then from that create an instance of cls.
+        if config is None:
+            # Empty config.
+            config = cls.Config()
+        elif isinstance(config, ConfigDescriptor):
+            config = validate_descriptor(config)
         else:
-            config = cls.Config.model_validate(config)
+            # Next handle dict | str, which could be that representing a Config or a ConfigDescriptor.
+            # First see if config is actually a descriptor by trying to create one, since it's only fields are limited
+            # to classinfo and config.
+            try:
+                descriptor = ConfigDescriptor.model_validate(config, context=dict(extra="forbid"))
+                config = validate_descriptor(descriptor)
+            except pydantic.ValidationError:
+                config = cls.Config.model_validate(config)
 
-        obj = cls(**config.model_dump())
-        obj._config = config
-        return obj
+        # Instantiate cls from config.
+        # Note: ``config`` is now a complete ``pydantic.BaseModel``, where all fields are adequately created. Any fields
+        # annotated as ``ConfigDescriptor`` will have automatically been converted to instances of ``ConfigDescriptor``,
+        # including lists & dicts of. One method to instantiate is ``cls(**config.model_dump())``, however,
+        # ``model_dump()`` will revert all of the above, resulting in any list & dicts of instances of
+        # ``ConfigDescriptor`` to be reverted back to native dicts. This is not desirable as we want to take advantage
+        # of pydantic having done the heavy lifting and keep config descriptors as actual instances so that they can
+        # be created calling ``ConfigDescriptor.create()``. ``model_dump()`` has no "shallow" semantics so we instead
+        # manually "dump" to dict using the following.
+        return cls(**dict(config))
 
     def __init__(self, *args, name: str = None, **kwargs):
-        self.name = name if name else self.__class__.__name__
+        # self.classinfo = self.__class__.fqn()
+        self.name = name or self.__class__.__name__
+        self.logger = None
         self._setup_logger()
-        self._config = None  # This is only populated if created using self.create() from a config.
+
+        # Automatically walk over all vars and instantiate any that are ConfigDescriptors.
+        # Note: To take advantage of this being here, and not having to explicitly call in child classes, the child's
+        # ``__init__`` must call ``super().__init__()`` last, not first. If this instantiation order is not desirable,
+        # simply call ``self.init_descriptors()`` explicitly from the child's ``__init__``.
+        self.init_descriptors(**kwargs)
+
+    def init_descriptors(self, **non_config_kwargs):
+        """ Automatically walk over all vars and instantiate any that are ConfigDescriptors. """
+        init_and_set_vars_from_descriptors(self, **non_config_kwargs)
 
     def _setup_logger(self):
         self.logger = logging.getLogger(self.name)
@@ -90,17 +219,59 @@ class BaseInterface(ABC):
         ch.setFormatter(formatter)
         self.logger.addHandler(ch)
 
+    @classmethod
+    def __get_pydantic_core_schema__(cls, *args, **kwargs):
+        return cls.Config.__get_pydantic_core_schema__(*args, **kwargs)
 
-class ConfigDescriptor(pydantic.BaseModel):
-    classinfo: pydantic.ImportString
-    config: dict = {}
+    @classmethod
+    def __get_pydantic_json_schema__(cls, *args, **kwargs):
+        return cls.Config.__get_pydantic_json_schema__(*args, **kwargs)
 
-    def create(self, **kwargs):
-        """ Create an instance of classinfo from a config.
+    @classmethod
+    def fqn(cls):
+        return f"{cls.__module__}.{cls.__qualname__}"
 
-            Args:
-                kwargs (:obj:`dict`): Key-value pairs used to override contents of ``self.config``.
+    @property
+    def config(self) -> dict:
+        """ Return a dict of Config populated from instance attributes.
+
+            Note: For convenience of converting back and forth from a ``ConfigDescriptor`` we return a ``dict`` rather
+                  than an instance of ``BaseConfig``.
         """
-        config = self.config.copy()
-        config.update(kwargs)
-        return self.classinfo.create(config)
+        return self.config_model.model_dump()
+
+    @property
+    def config_json(self) -> str:
+        """ Return a JSON str from a Config populated from instance attributes. """
+        return self.config_model.model_dump_json()
+
+    @property
+    def config_model(self) -> BaseConfig:
+        """ Return a dict of Config populated from instance attributes. """
+        return self.Config.model_validate(vars(self))
+
+    @property
+    def descriptor(self) -> ConfigDescriptor:
+        return ConfigDescriptor.model_validate(self)
+
+    @property
+    def classinfo(self):
+        return self.__class__.fqn()
+
+
+def init_and_set_vars_from_descriptors(obj, **non_config_kwargs):
+    """ Instantiate object vars that are ConfigDescriptors and set them on the object.
+        E.g., this can be called from a classes ``__init__`` as ``init_and_set_vars_from_descriptors(self)``.
+    """
+    for key, value in vars(obj).items():
+        if isinstance(value, ConfigDescriptor):
+            setattr(obj, key, value.create(non_config_kwargs=non_config_kwargs))
+        elif isinstance(value, list):
+            for i, x in enumerate(value):
+                if isinstance(x, ConfigDescriptor):
+                    value[i] = x.create(non_config_kwargs=non_config_kwargs)
+        elif isinstance(value, dict):
+            for k, v in value.items():
+                if isinstance(v, ConfigDescriptor):
+                    value[k] = v.create(non_config_kwargs=non_config_kwargs)
+                    value[k] = v.create(non_config_kwargs=non_config_kwargs)

--- a/evolver/base.py
+++ b/evolver/base.py
@@ -65,6 +65,17 @@ class _BaseConfig(pydantic.BaseModel):
                                           context=context)
         return super().model_validate(obj, strict=strict, from_attributes=from_attributes, context=context)
 
+    @classmethod
+    def load(cls, file_path: Path, encoding: str | None = None):
+        """Loads the specified config file and return a new instance."""
+        with open(file_path, encoding=encoding) as f:
+            return cls.model_validate(yaml.safe_load(f))
+
+    def save(self, file_path: Path, encoding: str | None = None):
+        """Write out config as yaml file to specified file."""
+        with open(file_path, 'w', encoding=encoding) as f:
+            yaml.dump(self.model_dump(mode='json'), f)
+
 
 class BaseConfig(_BaseConfig):
     name: str | None = None

--- a/evolver/base.py
+++ b/evolver/base.py
@@ -1,5 +1,4 @@
 from abc import ABC
-from collections import defaultdict
 import logging
 from pathlib import Path
 from typing import Annotated, Any, Dict
@@ -107,8 +106,8 @@ class ConfigDescriptor(_BaseConfig):
         return super().model_validate(obj, *args, **kwargs)
 
     def create(self,
-               update: Dict[str, Any] | None = defaultdict(),
-               non_config_kwargs: Dict[str, Any] | None = defaultdict(),
+               update: Dict[str, Any] | None = None,
+               non_config_kwargs: Dict[str, Any] | None = None,
                **kwargs):
         """ Create an instance of classinfo from a config.
 
@@ -123,7 +122,8 @@ class ConfigDescriptor(_BaseConfig):
         # Update config from kwargs.
         if update or kwargs:
             config = self.config.copy()
-            config.update(update)
+            if update:
+                config.update(update)
             config.update(kwargs)
         else:
             config = self.config
@@ -136,7 +136,8 @@ class ConfigDescriptor(_BaseConfig):
         config = self.classinfo.Config.model_validate(config)  # Note: we don't pass self due to update from kwargs.
 
         # Return an instance of classinfo.
-        return self.classinfo(**config.model_dump(), **non_config_kwargs)
+        return self.classinfo(**config.model_dump(), **non_config_kwargs) if non_config_kwargs else \
+            self.classinfo(**config.model_dump())
 
     @classmethod
     def load(cls, file_path: Path, encoding: str | None = None):

--- a/evolver/connection/interface.py
+++ b/evolver/connection/interface.py
@@ -13,11 +13,10 @@ class Connection(BaseInterface):
 
     backend = None  # Backend module/library to use.
 
-    def __init__(self, *args, config: Config = None, lock_constructor=RLock, **kwargs):
-        super().__init__(*args, **kwargs)
+    def __init__(self, *args, lock_constructor=RLock, **kwargs):
         self.conn = None  # This is the core object that this class wraps.
-        self.config = config or self.Config()
         self.lock = lock_constructor()
+        super().__init__(*args, **kwargs)
 
     @abstractmethod
     def _open(self,  *args, **kwargs):

--- a/evolver/controller/interface.py
+++ b/evolver/controller/interface.py
@@ -1,15 +1,15 @@
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 
-from evolver.base import BaseConfig
+from evolver.base import BaseConfig, BaseInterface
 
 
-class Controller(ABC):
+class Controller(BaseInterface):
     class Config(BaseConfig):
         ...
 
-    def __init__(self, evolver, config: Config = None):
-        self.config = config or self.Config()
+    def __init__(self, *args, evolver=None, **kwargs):
         self.evolver = evolver
+        super().__init__(*args, **kwargs)
 
     def pre_control(self, *args, **kwargs):
         """ Hook for customization pre-control execution, see self.run().

--- a/evolver/controller/standard/chemostat.py
+++ b/evolver/controller/standard/chemostat.py
@@ -6,41 +6,25 @@ from pydantic import Field
 from evolver.base import ConfigDescriptor
 from evolver.controller.interface import Controller
 from evolver.hardware.interface import VialConfigBaseModel, HardwareDriver
-from evolver.settings import settings
 
 
 class Chemostat(Controller):
     class Config(VialConfigBaseModel):
-        od_sensor: str = Field(description="name of OD sensor to use")
-        pump: str = Field(description="name of pump device to use")
-        stirrer: str = Field(description="name of stirrer device to use")
+        od_sensor: HardwareDriver | ConfigDescriptor | str = Field(description="name of OD sensor to use")
+        pump: HardwareDriver | ConfigDescriptor | str = Field(description="name of pump device to use")
+        stirrer: HardwareDriver | ConfigDescriptor | str = Field(description="name of stirrer device to use")
         window: int = Field(7, description="number of OD measurements to collect prior to start")
         min_od: float = Field(0, description="OD at which to start chemostat dilutions")
         start_delay: int = Field(0, description="Time (in hours) after which to start dilutions")
         flow_rate: float = Field(0, description="Flow rate for dilutions")
         stir_rate: float = Field(8, description="Stir rate")
 
-    def __init__(self,
-                 od_sensor: HardwareDriver | ConfigDescriptor | str,
-                 pump: HardwareDriver | ConfigDescriptor | str,
-                 stirrer: HardwareDriver | ConfigDescriptor | str,
-                 *args,
-                 vials: list = None,  # TODO: Derive this cls from a VialCentricController and add this there (#30).
-                 window: int = 7,
-                 min_od: float = 0,
-                 start_delay: int = 0,
-                 flow_rate: float = 0,
-                 stir_rate: float = 8,
-                 **kwargs):
-        self._od_sensor = od_sensor
-        self._pump = pump
-        self._stirrer = stirrer
-        self.vials = vials or list(range(settings.DEFAULT_NUMBER_OF_VIALS_PER_BOX))
-        self.window = window
-        self.min_od = min_od
-        self.start_delay = start_delay
-        self.flow_rate = flow_rate
-        self.stir_rate = stir_rate
+    def __init__(self, *args, **kwargs):
+        self._od_sensor = None
+        self._pump = None
+        self._stirrer = None
+
+        super().__init__(*args, **kwargs)
 
         # buffer could come from history as well
         self.od_buffer = defaultdict(lambda: deque(maxlen=self.window))
@@ -50,19 +34,38 @@ class Chemostat(Controller):
         # come from history similarly
         self.start_time = time.time()
 
-        super().__init__(*args, **kwargs)
-
     @property
     def od_sensor(self):
         return self.evolver.hardware.get(self._od_sensor) if isinstance(self._od_sensor, str) else self._od_sensor
+
+    @od_sensor.setter
+    def od_sensor(self, value):
+        if self._od_sensor is None:
+            self._od_sensor = value
+        else:
+            raise AttributeError()
 
     @property
     def pump(self):
         return self.evolver.hardware.get(self._pump) if isinstance(self._pump, str) else self._pump
 
+    @pump.setter
+    def pump(self, value):
+        if self._pump is None:
+            self._pump = value
+        else:
+            raise AttributeError()
+
     @property
     def stirrer(self):
         return self.evolver.hardware.get(self._stirrer) if isinstance(self._stirrer, str) else self._stirrer
+
+    @stirrer.setter
+    def stirrer(self, value):
+        if self._stirrer is None:
+            self._stirrer = value
+        else:
+            raise AttributeError()
 
     def control(self, *args, **kwargs):
         od_values = self.od_sensor.get()

--- a/evolver/controller/standard/chemostat.py
+++ b/evolver/controller/standard/chemostat.py
@@ -35,7 +35,7 @@ class Chemostat(Controller):
         self._od_sensor = od_sensor
         self._pump = pump
         self._stirrer = stirrer
-        self.vials = vials or list(range(settings.NUMBER_OF_VIALS_PER_BOX))
+        self.vials = vials or list(range(settings.DEFAULT_NUMBER_OF_VIALS_PER_BOX))
         self.window = window
         self.min_od = min_od
         self.start_delay = start_delay

--- a/evolver/controller/standard/tests/test_chemostat.py
+++ b/evolver/controller/standard/tests/test_chemostat.py
@@ -1,7 +1,7 @@
 import pytest
 from unittest.mock import MagicMock
 from evolver.controller.standard import Chemostat
-from evolver.device import Evolver, EvolverConfig
+from evolver.device import Evolver
 
 
 def add_mock_hardware(evolver):
@@ -36,8 +36,9 @@ def test_chemostat_standard_operation(mock_hardware, window, min_od, stir_rate, 
         min_od=min_od,
         stir_rate=stir_rate,
         flow_rate=flow_rate,
+        vials=[0, 1]
     )
-    c = Chemostat(mock_hardware, config)
+    c = Chemostat(evolver=mock_hardware, **config.model_dump())
     pump = mock_hardware.hardware['pump']
     stir = mock_hardware.hardware['stirrer']
 
@@ -64,16 +65,17 @@ def test_evolver_based_setup():  # test to ensure evolver pluggability via confi
     config = {
         'controllers': [
             {
-                'driver': 'evolver.controller.standard.Chemostat',
+                'classinfo': 'evolver.controller.standard.Chemostat',
                 'config': {
                     'od_sensor': 'od',
                     'pump': 'pump',
                     'stirrer': 'stirrer',
+                    'vials': [0, 1]
                 }
             }
         ]
     }
-    evolver = Evolver(EvolverConfig.model_validate(config))
+    evolver = Evolver.create(config)
     with pytest.raises(AttributeError):
         evolver.loop_once()
     add_mock_hardware(evolver)

--- a/evolver/device.py
+++ b/evolver/device.py
@@ -26,12 +26,8 @@ class Evolver(BaseInterface):
         enable_commit: bool = True
         interval: int = settings.DEFAULT_LOOP_INTERVAL
 
-    def __init__(self,
-                 *args,
-                 last_read=defaultdict(lambda: int(-1)),
-                 **kwargs):
-        self.last_read = last_read
-
+    def __init__(self, *args, **kwargs):
+        self.last_read = defaultdict(lambda: int(-1))
         super().__init__(*args, evolver=self, **kwargs)
 
     def get_hardware(self, name):

--- a/evolver/device.py
+++ b/evolver/device.py
@@ -18,10 +18,10 @@ class Evolver(BaseInterface):
     class Config(BaseConfig):
         name: str = "Evolver"
         vials: list = list(range(settings.DEFAULT_NUMBER_OF_VIALS_PER_BOX))
-        hardware: dict[str, ConfigDescriptor] = {}
-        controllers: list[ConfigDescriptor] = []
-        serial: ConfigDescriptor = ConfigDescriptor.model_validate(DEFAULT_SERIAL)
-        history:  ConfigDescriptor = ConfigDescriptor.model_validate(DEFAULT_HISTORY)
+        hardware: dict[str, ConfigDescriptor | HardwareDriver] = {}
+        controllers: list[ConfigDescriptor | Controller] = []
+        serial: ConfigDescriptor | Connection = ConfigDescriptor.model_validate(DEFAULT_SERIAL)
+        history:  ConfigDescriptor | HistoryServer = ConfigDescriptor.model_validate(DEFAULT_HISTORY)
         enable_control: bool = True
         enable_commit: bool = True
         interval: int = settings.DEFAULT_LOOP_INTERVAL

--- a/evolver/device.py
+++ b/evolver/device.py
@@ -17,7 +17,7 @@ DEFAULT_HISTORY = HistoryServer
 class Evolver(BaseInterface):
     class Config(BaseConfig):
         name: str = "Evolver"
-        vials: list = list(range(settings.NUMBER_OF_VIALS_PER_BOX))
+        vials: list = list(range(settings.DEFAULT_NUMBER_OF_VIALS_PER_BOX))
         hardware: dict[str, ConfigDescriptor] = {}
         controllers: list[ConfigDescriptor] = []
         serial: ConfigDescriptor = ConfigDescriptor.model_validate(DEFAULT_SERIAL)
@@ -28,7 +28,7 @@ class Evolver(BaseInterface):
 
     def __init__(self,
                  *args,
-                 hardware: dict[str, HardwareDriver | ConfigDescriptor] = defaultdict(),
+                 hardware: dict[str, HardwareDriver | ConfigDescriptor] = None,
                  controllers: list[Controller | ConfigDescriptor] = None,
                  vials: list = None,
                  serial: Connection | ConfigDescriptor = DEFAULT_SERIAL(),
@@ -38,10 +38,10 @@ class Evolver(BaseInterface):
                  enable_commit: bool = True,
                  interval: int = settings.DEFAULT_LOOP_INTERVAL,
                  **kwargs):
-        self.hardware = hardware
+        self.hardware = hardware if hardware is not None else {}
         self.last_read = last_read
-        self.controllers = controllers or []
-        self.vials = vials or list(range(settings.NUMBER_OF_VIALS_PER_BOX))
+        self.controllers = controllers if controllers is not None else []
+        self.vials = vials if vials is not None else list(range(settings.DEFAULT_NUMBER_OF_VIALS_PER_BOX))
         self.serial = serial
         self.history = history
         self.enable_control = enable_control

--- a/evolver/device.py
+++ b/evolver/device.py
@@ -1,84 +1,54 @@
+from collections import defaultdict
 import time
-import pydantic
-from typing import Annotated
 
-from evolver.base import BaseConfig
-from evolver.hardware.interface import SensorDriver, EffectorDriver
-from evolver.serial import EvolverSerialUART
+from evolver.base import BaseConfig, BaseInterface, ConfigDescriptor
+from evolver.connection.interface import Connection
+from evolver.controller.interface import Controller
+from evolver.hardware.interface import EffectorDriver, HardwareDriver, SensorDriver
 from evolver.history import HistoryServer
+from evolver.serial import EvolverSerialUART
+from evolver.settings import settings
 
 
 DEFAULT_SERIAL = EvolverSerialUART
 DEFAULT_HISTORY = HistoryServer
-# pydantics import string alone does not generate a schema, which breaks openapi
-# docs. We wrap it to set schema explicitly.
-ImportString = Annotated[
-    pydantic.ImportString, pydantic.WithJsonSchema({'type': 'string', 'description': 'fully qualified class name'})
-]
 
 
-class ControllerDescriptor(pydantic.BaseModel):
-    driver: ImportString
-    config: dict = {}
+class Evolver(BaseInterface):
+    class Config(BaseConfig):
+        name: str = "Evolver"
+        vials: list = list(range(settings.NUMBER_OF_VIALS_PER_BOX))
+        hardware: dict[str, ConfigDescriptor] = {}
+        controllers: list[ConfigDescriptor] = []
+        serial: ConfigDescriptor = ConfigDescriptor.model_validate(DEFAULT_SERIAL)
+        history:  ConfigDescriptor = ConfigDescriptor.model_validate(DEFAULT_HISTORY)
+        enable_control: bool = True
+        enable_commit: bool = True
+        interval: int = settings.DEFAULT_LOOP_INTERVAL
 
-    def driver_from_descriptor(self, evolver):
-        conf = self.driver.Config.model_validate(self.config)
-        return self.driver(evolver, conf)
+    def __init__(self,
+                 *args,
+                 hardware: dict[str, HardwareDriver | ConfigDescriptor] = defaultdict(),
+                 controllers: list[Controller | ConfigDescriptor] = None,
+                 vials: list = None,
+                 serial: Connection | ConfigDescriptor = DEFAULT_SERIAL(),
+                 history: HistoryServer | ConfigDescriptor = DEFAULT_HISTORY(),
+                 last_read=defaultdict(lambda: int(-1)),
+                 enable_control: bool = True,
+                 enable_commit: bool = True,
+                 interval: int = settings.DEFAULT_LOOP_INTERVAL,
+                 **kwargs):
+        self.hardware = hardware
+        self.last_read = last_read
+        self.controllers = controllers or []
+        self.vials = vials or list(range(settings.NUMBER_OF_VIALS_PER_BOX))
+        self.serial = serial
+        self.history = history
+        self.enable_control = enable_control
+        self.enable_commit = enable_commit
+        self.interval = interval
 
-
-class HardwareDriverDescriptor(ControllerDescriptor):
-    calibrator: ControllerDescriptor|None = None
-
-
-class EvolverConfig(BaseConfig):
-    name: str = "Evolver"
-    vials: list = list(range(16))
-    hardware: dict[str, HardwareDriverDescriptor] = {}
-    controllers: list[ControllerDescriptor] = []
-    serial: ControllerDescriptor = ControllerDescriptor(driver=DEFAULT_SERIAL)
-    history: ControllerDescriptor = ControllerDescriptor(driver=DEFAULT_HISTORY)
-    enable_control: bool = True
-    enable_commit: bool = True
-    interval: int = 20
-
-
-class Evolver:
-    def __init__(self, config: EvolverConfig = EvolverConfig()):
-        self.hardware = {}
-        self.last_read = {}
-        self.controllers = []
-        self.update_config(config)
-
-    def update_config(self, config: EvolverConfig):
-        self.config = config
-        for name, driver in config.hardware.items():
-            self.setup_driver(name, driver)
-        for name in list(self.hardware.keys()):
-            if name not in config.hardware.keys():
-                del(self.hardware[name])
-                del(self.last_read[name])
-        self.controllers = []
-        for controller in config.controllers:
-            self.setup_controller(controller)
-        if config.serial is not None:
-            self.serial = config.serial.driver_from_descriptor(self)
-        else:
-            self.serial = DEFAULT_SERIAL()
-        if config.history is not None:
-            self.history = config.history.driver_from_descriptor(self)
-        else:
-            self.history = DEFAULT_HISTORY()
-
-    def setup_driver(self, name, driver_config: HardwareDriverDescriptor):
-        config = driver_config.driver.Config.model_validate(driver_config.config)
-        calibrator = None
-        if driver_config.calibrator is not None:
-            calibrator = driver_config.calibrator.driver_from_descriptor(self)
-        self.hardware[name] = driver_config.driver(self, config, calibrator)
-        self.last_read[name] = -1
-
-    def setup_controller(self, controller):
-        self.controllers.append(controller.driver_from_descriptor(self))
+        super().__init__(*args, evolver=self, **kwargs)
 
     def get_hardware(self, name):
         return self.hardware[name]
@@ -131,7 +101,7 @@ class Evolver:
     def loop_once(self):
         self.read_state()
         # for any hardware awaiting calibration, call calibration update method here
-        if self.config.enable_control:
+        if self.enable_control:
             self.evaluate_controllers()
-        if self.config.enable_commit:
+        if self.enable_commit:
             self.commit_proposals()

--- a/evolver/device.py
+++ b/evolver/device.py
@@ -28,25 +28,9 @@ class Evolver(BaseInterface):
 
     def __init__(self,
                  *args,
-                 hardware: dict[str, HardwareDriver | ConfigDescriptor] = None,
-                 controllers: list[Controller | ConfigDescriptor] = None,
-                 vials: list = None,
-                 serial: Connection | ConfigDescriptor = DEFAULT_SERIAL(),
-                 history: HistoryServer | ConfigDescriptor = DEFAULT_HISTORY(),
                  last_read=defaultdict(lambda: int(-1)),
-                 enable_control: bool = True,
-                 enable_commit: bool = True,
-                 interval: int = settings.DEFAULT_LOOP_INTERVAL,
                  **kwargs):
-        self.hardware = hardware if hardware is not None else {}
         self.last_read = last_read
-        self.controllers = controllers if controllers is not None else []
-        self.vials = vials if vials is not None else list(range(settings.DEFAULT_NUMBER_OF_VIALS_PER_BOX))
-        self.serial = serial
-        self.history = history
-        self.enable_control = enable_control
-        self.enable_commit = enable_commit
-        self.interval = interval
 
         super().__init__(*args, evolver=self, **kwargs)
 

--- a/evolver/hardware/demo.py
+++ b/evolver/hardware/demo.py
@@ -7,11 +7,6 @@ class NoOpSensorDriver(SensorDriver):
         echo_raw: int = 1
         echo_val: int = 2
 
-    def __init__(self, *args, echo_raw: int = 1, echo_val: int = 2, **kwargs):
-        self.echo_raw = echo_raw
-        self.echo_val = echo_val
-        super().__init__(*args, **kwargs)
-
     def read(self):
         self.outputs = {
             i: self.Output(vial=i, raw=self.echo_raw, value=self.echo_val)

--- a/evolver/hardware/demo.py
+++ b/evolver/hardware/demo.py
@@ -7,10 +7,15 @@ class NoOpSensorDriver(SensorDriver):
         echo_raw: int = 1
         echo_val: int = 2
 
+    def __init__(self, *args, echo_raw: int = 1, echo_val: int = 2, **kwargs):
+        self.echo_raw = echo_raw
+        self.echo_val = echo_val
+        super().__init__(*args, **kwargs)
+
     def read(self):
         self.outputs = {
-            i: self.Output(vial=i, raw=self.config.echo_raw, value=self.config.echo_val)
-            for i in self.config.vials
+            i: self.Output(vial=i, raw=self.echo_raw, value=self.echo_val)
+            for i in self.vials
         }
 
     def get(self):

--- a/evolver/hardware/interface.py
+++ b/evolver/hardware/interface.py
@@ -39,9 +39,8 @@ class HardwareDriver(BaseInterface):
 
 
 class VialHardwareDriver(HardwareDriver):
-    def __init__(self, *args, **kwargs):
-        # self.vials = vials if vials else list(range(settings.DEFAULT_NUMBER_OF_VIALS_PER_BOX))
-        super().__init__(*args, **kwargs)
+    class Config(VialConfigBaseModel):
+        ...
 
 
 class SensorDriver(VialHardwareDriver):

--- a/evolver/hardware/interface.py
+++ b/evolver/hardware/interface.py
@@ -5,7 +5,7 @@ from evolver.settings import settings
 
 
 class VialConfigBaseModel(BaseConfig):
-    vials: list[int] | None = None
+    vials: list[int] | None = list(range(settings.DEFAULT_NUMBER_OF_VIALS_PER_BOX))
 
 
 class VialBaseModel(BaseConfig):
@@ -39,8 +39,8 @@ class HardwareDriver(BaseInterface):
 
 
 class VialHardwareDriver(HardwareDriver):
-    def __init__(self, *args, vials=None, **kwargs):
-        self.vials = vials if vials else list(range(settings.DEFAULT_NUMBER_OF_VIALS_PER_BOX))
+    def __init__(self, *args, **kwargs):
+        # self.vials = vials if vials else list(range(settings.DEFAULT_NUMBER_OF_VIALS_PER_BOX))
         super().__init__(*args, **kwargs)
 
 

--- a/evolver/hardware/interface.py
+++ b/evolver/hardware/interface.py
@@ -1,6 +1,7 @@
 from abc import abstractmethod
 
 from evolver.base import BaseConfig, BaseInterface
+from evolver.settings import settings
 
 
 class VialConfigBaseModel(BaseConfig):
@@ -15,8 +16,8 @@ class BaseCalibrator(BaseInterface):
     class Config(BaseConfig):
         calibfile: str = None
 
-    def __init__(self, *args, evovler=None, **kwargs):
-        self.evovler = evovler
+    def __init__(self, *args, evolver=None, **kwargs):
+        self.evolver = evolver
         super().__init__(*args, **kwargs)
 
     @property
@@ -39,7 +40,7 @@ class HardwareDriver(BaseInterface):
 
 class VialHardwareDriver(HardwareDriver):
     def __init__(self, *args, vials=None, **kwargs):
-        self.vials = vials if vials else list(range(16))
+        self.vials = vials if vials else list(range(settings.DEFAULT_NUMBER_OF_VIALS_PER_BOX))
         super().__init__(*args, **kwargs)
 
 

--- a/evolver/history.py
+++ b/evolver/history.py
@@ -1,11 +1,12 @@
 import time
-import pydantic
-from abc import ABC, abstractmethod
+from abc import abstractmethod
 from collections import defaultdict
 
+from evolver.base import BaseConfig, BaseInterface
 
-class History(ABC):
-    class Config(pydantic.BaseModel):
+
+class History(BaseInterface):
+    class Config(BaseConfig):
         pass
 
     @abstractmethod
@@ -18,10 +19,12 @@ class History(ABC):
 
 
 class HistoryServer(History):
-    def __init__(self, evolver=None, config=None):
-        self.evolver = evolver
-        self.config = config
-        self.history = defaultdict(list)
+    class Config(History.Config):
+        name: str = "HistoryServer"
+
+    def __init__(self, *args, history=defaultdict(list), **kwargs):
+        self.history = history
+        super().__init__(*args, **kwargs)
 
     def put(self, name, data):
         self.history[name].append((time.time(), data))

--- a/evolver/history.py
+++ b/evolver/history.py
@@ -1,6 +1,6 @@
-import time
 from abc import abstractmethod
 from collections import defaultdict
+import time
 
 from evolver.base import BaseConfig, BaseInterface
 
@@ -22,8 +22,8 @@ class HistoryServer(History):
     class Config(History.Config):
         name: str = "HistoryServer"
 
-    def __init__(self, *args, history=defaultdict(list), **kwargs):
-        self.history = history
+    def __init__(self, *args, **kwargs):
+        self.history = defaultdict(list)
         super().__init__(*args, **kwargs)
 
     def put(self, name, data):

--- a/evolver/serial.py
+++ b/evolver/serial.py
@@ -21,12 +21,19 @@ class EvolverSerialUART(Connection):
         RESP_SUFFIX = b'end'
 
     class Config(pydantic.BaseModel):
+        name: str = "EvolverSerialUART"
         port: str = '/dev/ttyAMA0'
         baudrate: int = 9600
         timeout: float = 1
 
+    def __init__(self, *args, port: str = '/dev/ttyAMA0', baudrate: int = 9600, timeout: float = 1, **kwargs):
+        self.port = port
+        self.baudrate = baudrate
+        self.timeout = timeout
+        super().__init__(*args, **kwargs)
+
     def _open(self):
-        return self.backend.Serial(port=self.config.port, baudrate=self.config.baudrate, timeout=self.config.timeout)
+        return self.backend.Serial(port=self.port, baudrate=self.baudrate, timeout=self.timeout)
 
     def _close(self):
         return self.conn.close()

--- a/evolver/serial.py
+++ b/evolver/serial.py
@@ -26,12 +26,6 @@ class EvolverSerialUART(Connection):
         baudrate: int = 9600
         timeout: float = 1
 
-    def __init__(self, *args, port: str = '/dev/ttyAMA0', baudrate: int = 9600, timeout: float = 1, **kwargs):
-        self.port = port
-        self.baudrate = baudrate
-        self.timeout = timeout
-        super().__init__(*args, **kwargs)
-
     def _open(self):
         return self.backend.Serial(port=self.port, baudrate=self.baudrate, timeout=self.timeout)
 

--- a/evolver/settings.py
+++ b/evolver/settings.py
@@ -8,6 +8,8 @@ class BaseSettings(pydantic_settings.BaseSettings):
 
 class Settings(BaseSettings):
     CONNECTION_REUSE_POLICY_DEFAULT: bool = True
+    DEFAULT_LOOP_INTERVAL: int = 20
+    NUMBER_OF_VIALS_PER_BOX: int = 16
 
 
 class AppSettings(BaseSettings):

--- a/evolver/settings.py
+++ b/evolver/settings.py
@@ -9,7 +9,7 @@ class BaseSettings(pydantic_settings.BaseSettings):
 class Settings(BaseSettings):
     CONNECTION_REUSE_POLICY_DEFAULT: bool = True
     DEFAULT_LOOP_INTERVAL: int = 20
-    NUMBER_OF_VIALS_PER_BOX: int = 16
+    DEFAULT_NUMBER_OF_VIALS_PER_BOX: int = 16
 
 
 class AppSettings(BaseSettings):

--- a/evolver/tests/test_device.py
+++ b/evolver/tests/test_device.py
@@ -1,66 +1,124 @@
+import json
+
 import pytest
-from evolver.device import Evolver, EvolverConfig
+
+import evolver.base
+from evolver.connection.interface import Connection
+from evolver.controller.interface import Controller
+from evolver.device import Evolver
+from evolver.hardware.interface import HardwareDriver
 from evolver.hardware.demo import NoOpSensorDriver
+from evolver.history import History
 
 
 @pytest.fixture
 def conf_with_driver():
     return {
+        'name': "evolver",
         'vials': [0,1,2,3],
         'hardware': {
             'testsensor': {
-                'driver':
-                'evolver.hardware.demo.NoOpSensorDriver',
-                'config': {},
-                'calibrator': {
-                    'driver': 'evolver.hardware.demo.NoOpCalibrator'
-                }
+                'classinfo': 'evolver.hardware.demo.NoOpSensorDriver',
+                'config': {'calibrator': {'classinfo': 'evolver.hardware.demo.NoOpCalibrator', 'config': {}}}
             },
-            'testeffector': {'driver': 'evolver.hardware.demo.NoOpEffectorDriver', 'config': {}},
+            'testeffector': {'classinfo': 'evolver.hardware.demo.NoOpEffectorDriver', 'config': {}},
         },
         'controllers': [
-            {'driver': 'evolver.controller.demo.NoOpController'},
+            {'classinfo': 'evolver.controller.demo.NoOpController', 'config': {}},
         ],
-        'serial': { 'driver': 'evolver.serial.EvolverSerialUARTEmulator' },
+        'serial': {'classinfo': 'evolver.serial.EvolverSerialUARTEmulator'},
     }
 
 
 @pytest.fixture
 def demo_evolver(conf_with_driver):
-    return Evolver(EvolverConfig.model_validate(conf_with_driver))
+    return Evolver.create(conf_with_driver)
 
 
-def test_evolver_instantiate_with_default_config():
-    conf = EvolverConfig()
-    evolver = Evolver()
-    evolver.update_config(conf)
-    Evolver(conf)
+class TestEvolver:
+    def test_empty_config(self):
+        obj = Evolver.Config()
+        assert isinstance(obj, evolver.base.BaseConfig)
+        assert isinstance(obj.serial, evolver.base.ConfigDescriptor)
+        assert isinstance(obj.history, evolver.base.ConfigDescriptor)
 
+    def test_instantiate_with_default_config(self):
+        obj = Evolver.create()
+        assert isinstance(obj, evolver.base.BaseInterface)
+        assert isinstance(obj.serial, Connection)
+        assert isinstance(obj.history, History)
 
-def test_evolver_with_driver(demo_evolver):
-    assert isinstance(demo_evolver.hardware['testsensor'], NoOpSensorDriver)
+    def test_instantiate_from_conf(self, conf_with_driver):
+        obj = Evolver.create(conf_with_driver)
+        assert isinstance(obj, Evolver)
+        assert isinstance(obj.serial, Connection)
+        assert isinstance(obj.hardware, dict)
+        assert isinstance(obj.vials, list)
+        assert isinstance(obj.controllers, list)
 
+        for v in obj.hardware.values():
+            assert isinstance(v, HardwareDriver)
 
-@pytest.mark.parametrize('method', ['read_state', 'loop_once'])
-def test_evolver_read_and_get_state(demo_evolver, method):
-    state = demo_evolver.state
-    assert state['testsensor'] == {}
-    getattr(demo_evolver, method)()
-    state = demo_evolver.state
-    for vial in demo_evolver.config.vials:
-        assert state['testsensor'][vial] == NoOpSensorDriver.Output(vial=vial, raw=1, value=2)
+        for item in obj.controllers:
+            assert isinstance(item, Controller)
 
+    def test_descriptor_serialization(self, conf_with_driver):
+        obj = Evolver.create(conf_with_driver)
+        obj.descriptor.model_dump_json()
 
-@pytest.mark.parametrize('enable_control', [True, False])
-def test_evolver_controller_control_in_loop_if_configured(demo_evolver, enable_control):
-    assert demo_evolver.controllers[0].ncalls == 0
-    demo_evolver.config.enable_control = enable_control
-    demo_evolver.loop_once()
-    assert demo_evolver.controllers[0].ncalls == (1 if enable_control else 0)
+    def test_config_correctness_from_conf(self, conf_with_driver):
+        obj = Evolver.create(conf_with_driver)
 
+        # These should only differ by classinfo, in that ``classinfo`` keys in ``obj.config`` will be types whilst those
+        # in ``obj.descriptor.config`` will be str of their fqn. See Note in ``evolver.base.ConfigDescriptor.model_validate()``.
+        assert obj.config != obj.descriptor.config
 
-def test_evolver_remove_driver(demo_evolver, conf_with_driver):
-    assert 'testeffector' in demo_evolver.hardware
-    del(conf_with_driver['hardware']['testeffector'])
-    demo_evolver.update_config(EvolverConfig.model_validate(conf_with_driver))
-    assert 'testeffector' not in demo_evolver.hardware
+        assert obj.config_json == json.dumps(obj.descriptor.config, separators=(',', ':'))
+        obj2 = Evolver.create(obj.config_json)
+        # Note: We can't just test obj.config_json == conf_with_driver because the latter contains empty sub-configs
+        # and the former will contain sub-configs with default field values.
+        assert obj2.config == obj.config
+        assert obj2.config_json == obj.config_json
+
+    def test_empty_config_property_equivalence(self):
+        obj1 = Evolver.create()
+        obj2 = Evolver.Config()
+        assert obj1.config == obj2.model_dump()
+
+    def test_config_symmetry(self):
+        obj1 = Evolver.create()
+        obj2 = Evolver.create(obj1.config)
+        assert obj1.config == obj2.config
+
+    def test_config_symmetry_from_conf(self, conf_with_driver):
+        obj1 = Evolver.create(conf_with_driver)
+        obj2 = Evolver.create(obj1.config)
+        assert obj1.config == obj2.config
+
+    def test_with_driver(self, demo_evolver):
+        assert isinstance(demo_evolver.hardware['testsensor'], NoOpSensorDriver)
+
+    @pytest.mark.parametrize('method', ['read_state', 'loop_once'])
+    def test_read_and_get_state(self, demo_evolver, method):
+        state = demo_evolver.state
+        assert state['testsensor'] == {}
+        getattr(demo_evolver, method)()
+        state = demo_evolver.state
+        for vial in demo_evolver.vials:
+            assert state['testsensor'][vial] == NoOpSensorDriver.Output(vial=vial, raw=1, value=2)
+
+    @pytest.mark.parametrize('enable_control', [True, False])
+    def test_controller_control_in_loop_if_configured(self, demo_evolver, enable_control):
+        assert demo_evolver.controllers[0].ncalls == 0
+        demo_evolver.enable_control = enable_control
+        demo_evolver.loop_once()
+        assert demo_evolver.controllers[0].ncalls == (1 if enable_control else 0)
+
+    def test_remove_driver(self, demo_evolver, conf_with_driver):
+        assert 'testeffector' in demo_evolver.hardware
+        del(conf_with_driver['hardware']['testeffector'])
+        obj = Evolver.create(conf_with_driver)
+        assert 'testeffector' not in obj.hardware
+
+    def test_schema(self):
+        Evolver.Config.model_json_schema()

--- a/evolver/tests/test_device.py
+++ b/evolver/tests/test_device.py
@@ -68,10 +68,7 @@ class TestEvolver:
 
     def test_config_correctness_from_conf(self, conf_with_driver):
         obj = Evolver.create(conf_with_driver)
-
-        # These should only differ by classinfo, in that ``classinfo`` keys in ``obj.config`` will be types whilst those
-        # in ``obj.descriptor.config`` will be str of their fqn. See Note in ``evolver.base.ConfigDescriptor.model_validate()``.
-        assert obj.config != obj.descriptor.config
+        assert obj.config == obj.descriptor.config
 
         assert obj.config_json == json.dumps(obj.descriptor.config, separators=(',', ':'))
         obj2 = Evolver.create(obj.config_json)
@@ -83,7 +80,7 @@ class TestEvolver:
     def test_empty_config_property_equivalence(self):
         obj1 = Evolver.create()
         obj2 = Evolver.Config()
-        assert obj1.config == obj2.model_dump()
+        assert obj1.config == obj2.model_dump(mode="json")
 
     def test_config_symmetry(self):
         obj1 = Evolver.create()

--- a/evolver/tests/test_device.py
+++ b/evolver/tests/test_device.py
@@ -5,7 +5,7 @@ import pytest
 import evolver.base
 from evolver.connection.interface import Connection
 from evolver.controller.interface import Controller
-from evolver.device import Evolver
+from evolver.device import Evolver, DEFAULT_SERIAL, DEFAULT_HISTORY
 from evolver.hardware.interface import HardwareDriver
 from evolver.hardware.demo import NoOpSensorDriver
 from evolver.history import History
@@ -119,3 +119,10 @@ class TestEvolver:
 
     def test_schema(self):
         Evolver.Config.model_json_schema()
+
+    def test_non_descriptor_config_field(self):
+        obj = Evolver(hardware={"a": NoOpSensorDriver()}, serial=DEFAULT_SERIAL(), history=DEFAULT_HISTORY())
+        assert len(obj.hardware) == 1
+        assert isinstance(obj.hardware["a"], NoOpSensorDriver)
+        assert isinstance(obj.serial, DEFAULT_SERIAL)
+        assert isinstance(obj.history, DEFAULT_HISTORY)

--- a/evolver/util.py
+++ b/evolver/util.py
@@ -11,3 +11,8 @@ def find_package_location(package=__project__):
 
 def find_repo_location(package=__project__):
     return Path(find_package_location(package) / os.pardir)
+
+
+def fully_qualified_name(cls):
+    """ The fully qualified classname for cls. """
+    return f"{cls.__module__}.{cls.__qualname__}"


### PR DESCRIPTION
Resolves #53
Resolves #67

# Changes:
 - This propagates the constructor pattern added in #37 to all other classes.
   - adds full init sigs to classes rather than just passing and storing a config.
   - unpacks config to actual instance attributes, i.e., internally stuff isn't ref'd by ``self.config.attr`` but ``self.attr``. 
   -  add ``*args``, ``**kwargs``, and call to ``super().__init__()`` to allow for inheritance.
 - Some extensions to that laid out in #37 have been added.
   - Ease of conversion between ``BaseConfig``, ``ConfigDescriptor``, and ``BaseInterface``.
   - Add some helper functionality for instantiating nested config descriptors (originally proposed in #35)
   - ``config`` & ``descriptor`` properties 
