### PR TITLE
Post review changes to #74

### DIFF
--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -3,8 +3,7 @@ from fastapi import FastAPI
 
 from evolver.base import require_all_fields
 from evolver.device import Evolver, EvolverConfig
-from evolver.settings import settings
-from evolver.util import load_config_for_evolver, save_evolver_config
+from evolver.settings import app_settings
 from .. import __project__, __version__
 
 
@@ -37,7 +36,8 @@ async def get_state():
 @app.post("/")
 async def update_evolver(config: EvolverConfigWithoutDefaults):
     evolver.update_config(config)
-    save_evolver_config(config, settings.CONFIG_FILE)
+    evolver.config.save(app_settings.CONFIG_FILE)
+
 
 @app.get('/schema')
 async def get_schema():
@@ -67,15 +67,15 @@ async def start_evolver_loop():
 
 @app.on_event('startup')
 async def load_config():
-    load_config_for_evolver(evolver, settings.CONFIG_FILE)
+    evolver.update_config(EvolverConfig.load(app_settings.CONFIG_FILE))
 
 
 def start():
     import uvicorn
     uvicorn.run(
         app,
-        host=settings.HOST,
-        port=settings.PORT,
+        host=app_settings.HOST,
+        port=app_settings.PORT,
         log_level="info"
     )
 

--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -1,4 +1,6 @@
 import asyncio
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI
 
 from evolver.base import require_all_fields
@@ -7,8 +9,20 @@ from evolver.settings import app_settings
 from .. import __project__, __version__
 
 
-app = FastAPI()
-evolver = Evolver()
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Startup:
+    app.evolver = Evolver()
+    if app_settings.LOAD_FROM_CONFIG_ON_STARTUP:
+        app.evolver.update_config(EvolverConfig.load(app_settings.CONFIG_FILE))
+    asyncio.create_task(evolver_async_loop())
+    yield
+    # Shutdown:
+    ...
+
+
+app = FastAPI(lifespan=lifespan)
+app.evolver = None
 
 
 @require_all_fields
@@ -19,34 +33,34 @@ class EvolverConfigWithoutDefaults(EvolverConfig):
 @app.get("/")
 async def describe_evolver():
     return {
-        'config': evolver.config,
-        'state': evolver.state,
-        'last_read': evolver.last_read,
+        'config': app.evolver.config,
+        'state': app.evolver.state,
+        'last_read': app.evolver.last_read,
     }
 
 
 @app.get('/state')
 async def get_state():
     return {
-        'state': evolver.state,
-        'last_read': evolver.last_read,
+        'state': app.evolver.state,
+        'last_read': app.evolver.last_read,
     }
 
 
 @app.post("/")
 async def update_evolver(config: EvolverConfigWithoutDefaults):
-    evolver.update_config(config)
-    evolver.config.save(app_settings.CONFIG_FILE)
+    app.evolver.update_config(config)
+    app.evolver.config.save(app_settings.CONFIG_FILE)
 
 
 @app.get('/schema')
 async def get_schema():
-    return evolver.schema
+    return app.evolver.schema
 
 
 @app.get('/history/{name}')
 async def get_history(name: str):
-    return evolver.history.get(name)
+    return app.evolver.history.get(name)
 
 
 @app.get("/healthz")
@@ -56,18 +70,8 @@ async def healthz():
 
 async def evolver_async_loop():
     while True:
-        evolver.loop_once()
-        await asyncio.sleep(evolver.config.interval)
-
-
-@app.on_event('startup')
-async def start_evolver_loop():
-    asyncio.create_task(evolver_async_loop())
-
-
-@app.on_event('startup')
-async def load_config():
-    evolver.update_config(EvolverConfig.load(app_settings.CONFIG_FILE))
+        app.evolver.loop_once()
+        await asyncio.sleep(app.evolver.config.interval)
 
 
 def start():

--- a/evolver/app/tests/conftest.py
+++ b/evolver/app/tests/conftest.py
@@ -1,10 +1,17 @@
-import os
 import pytest
 from fastapi.testclient import TestClient
-from ..main import app  # Leave as relative for use in template: ssec-jhu/base-template.
+
+from evolver.app.main import app
+from evolver.device import EvolverConfig
+from evolver.settings import app_settings
 
 
-@pytest.fixture(scope="class")
-def app_client(tmp_path_factory):
-    os.chdir(tmp_path_factory.mktemp('test_dir'))
-    return TestClient(app)
+@pytest.fixture(scope="function")
+def app_client(tmp_path, monkeypatch):
+    monkeypatch.setattr(app_settings, "CONFIG_FILE", tmp_path / app_settings.CONFIG_FILE)
+
+    # Create and save a default config file to be read upon app startup.
+    EvolverConfig().save(app_settings.CONFIG_FILE)
+
+    with TestClient(app) as client:
+        yield client

--- a/evolver/app/tests/conftest.py
+++ b/evolver/app/tests/conftest.py
@@ -6,7 +6,7 @@ from evolver.device import EvolverConfig
 from evolver.settings import app_settings
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 def app_client(tmp_path, monkeypatch):
     monkeypatch.setattr(app_settings, "CONFIG_FILE", tmp_path / app_settings.CONFIG_FILE)
 

--- a/evolver/app/tests/test_app.py
+++ b/evolver/app/tests/test_app.py
@@ -1,11 +1,13 @@
-import os
 import json
 import yaml
+
 from fastapi.openapi.utils import get_openapi
 from fastapi.testclient import TestClient
+
+from evolver import __version__
 from evolver.settings import app_settings
 from evolver.device import EvolverConfig, HardwareDriverDescriptor
-from ..main import app, evolver, __version__, EvolverConfigWithoutDefaults
+from evolver.app.main import app, EvolverConfigWithoutDefaults
 
 
 class TestApp:
@@ -35,7 +37,7 @@ class TestApp:
         EvolverConfigWithoutDefaults.model_validate_json(EvolverConfig().model_dump_json())
 
     def test_evolver_update_config_endpoint(self, app_client):
-        assert not app_settings.CONFIG_FILE.exists()  # in these test we do not have a stored config at load time
+        assert app_settings.CONFIG_FILE.exists()  # Note: app_client generates an default config and saves to file.
         data = {'hardware': {'test': {'driver': 'evolver.hardware.demo.NoOpSensorDriver'}}}
         response = app_client.post('/', json=data)
         # all config fields are required so the above post failed with an Unprocessable Entity error.
@@ -55,19 +57,16 @@ class TestApp:
         assert saved['hardware']['test']['driver'] == 'evolver.hardware.demo.NoOpSensorDriver'
 
     def test_evolver_app_control_loop_setup(self, app_client):
-        # The context manager ensures that startup event loop is called
         # TODO: check results generated in control() (may require hardware at startup, or forced execution of loop)
-        with app_client as client:
-            response = client.get('/')
-            assert response.status_code == 200
+        response = app_client.get('/')
+        assert response.status_code == 200
 
 
-def test_app_load_file(tmp_path):
-    os.chdir(tmp_path)
+def test_app_load_file(app_client):
     config = EvolverConfig(hardware={
         'file_test': HardwareDriverDescriptor(driver='evolver.hardware.demo.NoOpSensorDriver')
     })
     config.save(app_settings.CONFIG_FILE)
-    evolver.update_config(EvolverConfig.load(app_settings.CONFIG_FILE))
+    app.evolver.update_config(EvolverConfig.load(app_settings.CONFIG_FILE))
     client = TestClient(app)
     client.get('/').json()['config']['hardware']['file_test']['driver'] == 'evolver.hardware.demo.NoOpSensorDriver'

--- a/evolver/app/tests/test_app.py
+++ b/evolver/app/tests/test_app.py
@@ -3,9 +3,8 @@ import json
 import yaml
 from fastapi.openapi.utils import get_openapi
 from fastapi.testclient import TestClient
-from evolver.settings import settings
+from evolver.settings import app_settings
 from evolver.device import EvolverConfig, HardwareDriverDescriptor
-from evolver.util import load_config_for_evolver, save_evolver_config
 from ..main import app, evolver, __version__, EvolverConfigWithoutDefaults
 
 
@@ -36,7 +35,7 @@ class TestApp:
         EvolverConfigWithoutDefaults.model_validate_json(EvolverConfig().model_dump_json())
 
     def test_evolver_update_config_endpoint(self, app_client):
-        assert not settings.CONFIG_FILE.exists()  # in these test we do not have a stored config at load time
+        assert not app_settings.CONFIG_FILE.exists()  # in these test we do not have a stored config at load time
         data = {'hardware': {'test': {'driver': 'evolver.hardware.demo.NoOpSensorDriver'}}}
         response = app_client.post('/', json=data)
         # all config fields are required so the above post failed with an Unprocessable Entity error.
@@ -51,8 +50,8 @@ class TestApp:
         newconfig = app_client.get('/').json()['config']
         assert newconfig['hardware']['test']['driver'] == 'evolver.hardware.demo.NoOpSensorDriver'
         # check we wrote out a file
-        with open(settings.CONFIG_FILE) as f:
-            saved = yaml.load(f, yaml.SafeLoader)
+        with open(app_settings.CONFIG_FILE) as f:
+            saved = yaml.safe_load(f)
         assert saved['hardware']['test']['driver'] == 'evolver.hardware.demo.NoOpSensorDriver'
 
     def test_evolver_app_control_loop_setup(self, app_client):
@@ -68,7 +67,7 @@ def test_app_load_file(tmp_path):
     config = EvolverConfig(hardware={
         'file_test': HardwareDriverDescriptor(driver='evolver.hardware.demo.NoOpSensorDriver')
     })
-    save_evolver_config(config, settings.CONFIG_FILE)
-    load_config_for_evolver(evolver, settings.CONFIG_FILE)
+    config.save(app_settings.CONFIG_FILE)
+    evolver.update_config(EvolverConfig.load(app_settings.CONFIG_FILE))
     client = TestClient(app)
     client.get('/').json()['config']['hardware']['file_test']['driver'] == 'evolver.hardware.demo.NoOpSensorDriver'

--- a/evolver/app/tests/test_app.py
+++ b/evolver/app/tests/test_app.py
@@ -67,6 +67,6 @@ def test_app_load_file(app_client):
         'file_test': HardwareDriverDescriptor(driver='evolver.hardware.demo.NoOpSensorDriver')
     })
     config.save(app_settings.CONFIG_FILE)
-    app.evolver.update_config(EvolverConfig.load(app_settings.CONFIG_FILE))
+    app.state.evolver.update_config(EvolverConfig.load(app_settings.CONFIG_FILE))
     client = TestClient(app)
     client.get('/').json()['config']['hardware']['file_test']['driver'] == 'evolver.hardware.demo.NoOpSensorDriver'

--- a/evolver/base.py
+++ b/evolver/base.py
@@ -1,8 +1,10 @@
 from abc import ABC
 import logging
+from pathlib import Path
 
 import pydantic
 import pydantic_core
+import yaml
 
 
 def require_all_fields(cls):
@@ -33,6 +35,17 @@ def require_all_fields(cls):
 
 class BaseConfig(pydantic.BaseModel):
     name: str = None
+
+    @classmethod
+    def load(cls, file_path: Path, encoding: str | None = None):
+        """Loads the specified config file and return a new instance."""
+        with open(file_path, encoding=encoding) as f:
+            return cls.model_validate(yaml.safe_load(f))
+
+    def save(self, file_path: Path, encoding: str | None = None):
+        """Write out config as yaml file to specified file."""
+        with open(file_path, 'w', encoding=encoding) as f:
+            yaml.dump(self.model_dump(mode='json'), f)
 
 
 class BaseInterface(ABC):

--- a/evolver/device.py
+++ b/evolver/device.py
@@ -1,6 +1,8 @@
 import time
 import pydantic
 from typing import Annotated
+
+from evolver.base import BaseConfig
 from evolver.hardware.interface import SensorDriver, EffectorDriver
 from evolver.serial import EvolverSerialUART
 from evolver.history import HistoryServer
@@ -28,7 +30,8 @@ class HardwareDriverDescriptor(ControllerDescriptor):
     calibrator: ControllerDescriptor|None = None
 
 
-class EvolverConfig(pydantic.BaseModel):
+class EvolverConfig(BaseConfig):
+    name: str = "Evolver"
     vials: list = list(range(16))
     hardware: dict[str, HardwareDriverDescriptor] = {}
     controllers: list[ControllerDescriptor] = []

--- a/evolver/settings.py
+++ b/evolver/settings.py
@@ -1,15 +1,20 @@
 from pathlib import Path
-from pydantic_settings import BaseSettings, SettingsConfigDict
+import pydantic_settings
+
+
+class BaseSettings(pydantic_settings.BaseSettings):
+    model_config = pydantic_settings.SettingsConfigDict(env_prefix="EVOLVER_", case_sensitive=True)
 
 
 class Settings(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix="EVOLVER_",
-                                      case_sensitive=True)
-
     CONNECTION_REUSE_POLICY_DEFAULT: bool = True
+
+
+class AppSettings(BaseSettings):
     CONFIG_FILE: Path = Path('evolver.yml')  # in current directory
     HOST: str = "127.0.0.1"
     PORT: int = 8080
 
 
 settings = Settings()
+app_settings = AppSettings()

--- a/evolver/settings.py
+++ b/evolver/settings.py
@@ -12,6 +12,7 @@ class Settings(BaseSettings):
 
 class AppSettings(BaseSettings):
     CONFIG_FILE: Path = Path('evolver.yml')  # in current directory
+    LOAD_FROM_CONFIG_ON_STARTUP: bool = True
     HOST: str = "127.0.0.1"
     PORT: int = 8080
 

--- a/evolver/util.py
+++ b/evolver/util.py
@@ -1,9 +1,6 @@
 import importlib
 import os
-import yaml
 from pathlib import Path
-
-from evolver.device import Evolver, EvolverConfig
 
 from . import __project__  # Keep as relative for templating reasons.
 
@@ -14,16 +11,3 @@ def find_package_location(package=__project__):
 
 def find_repo_location(package=__project__):
     return Path(find_package_location(package) / os.pardir)
-
-
-def load_config_for_evolver(evolver: Evolver, configfile: Path):
-    """Loads the specified config file and applies to evolver."""
-    if configfile.exists():
-        with open(configfile) as f:
-            evolver.update_config(EvolverConfig.model_validate(yaml.load(f, yaml.SafeLoader)))
-
-
-def save_evolver_config(config: EvolverConfig, configfile: Path):
-    """Write out evolver config as yaml file to specified file."""
-    with open(configfile, 'w') as f:
-        yaml.dump(config.model_dump(mode='json'), f)


### PR DESCRIPTION
Improvements to #74
Resolves #67 

 - Adds ``save`` and ``load`` methods to ``evolver.base.BaseConfig``
 - Separate settings for application settings.
 - Reading the docs, it's now better to use a lifespan event rather than individual startup and shutdown events.
 - Instantiate app ``evolver`` instance on startup, not at module level. (This required #67 to be resolved - see https://github.com/ssec-jhu/evolver-ng/issues/67#issuecomment-2135687714)

See https://github.com/ssec-jhu/evolver-ng/pull/74#issuecomment-2135456108
>I think the files should rep descriptors not just the config such that the file also has the classinfo so that when looking at a config file you know what model it's for.

Also, we should note that ``pydantic`` has similar functionality for reading from files [YamlConfigSettingsSource](https://docs.pydantic.dev/latest/api/pydantic_settings/#pydantic_settings.YamlConfigSettingsSource) but isn't quite what we want.