### PR TITLE
pump and stir

### DIFF
--- a/evolver/hardware/standard/pump.py
+++ b/evolver/hardware/standard/pump.py
@@ -21,7 +21,7 @@ class GenericPump(EffectorDriver):
     non-IPP pumps.
     """
 
-    class Config(SerialDeviceConfigBase):
+    class Config(SerialDeviceConfigBase, EffectorDriver.Config):
         ipp_pumps: bool | list[int] = Field(False, description="False (no IPP), True (all IPP), or list of IPP ids")
 
     class Input(BaseConfig):

--- a/evolver/hardware/standard/pump.py
+++ b/evolver/hardware/standard/pump.py
@@ -86,7 +86,7 @@ class VialIEPump(EffectorDriver):
 
     class Input(VialBaseModel):
         flow_rate_influx: float = Field(description="influx flow rate in ml/s")
-        flow_rate_efflux: float | None = Field(None, description="efflux flow rate in ml/s. Defaults to same as influx")
+        flow_rate_efflux: float = Field(description="efflux flow rate in ml/s")
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -104,8 +104,6 @@ class VialIEPump(EffectorDriver):
     def commit(self):
         for p in self.proposal.values():
             if p.vial in self.vials:
-                if p.flow_rate_efflux is None:
-                    p.flow_rate_efflux = p.flow_rate_influx
                 self._generic_pump.set(GenericPump.Input(pump_id=self.influx_map[p.vial], flow_rate=p.flow_rate_influx))
                 self._generic_pump.set(GenericPump.Input(pump_id=self.efflux_map[p.vial], flow_rate=p.flow_rate_efflux))
         self._generic_pump.commit()

--- a/evolver/hardware/standard/pump.py
+++ b/evolver/hardware/standard/pump.py
@@ -1,0 +1,105 @@
+from copy import copy
+
+from pydantic import Field
+
+from evolver.base import BaseConfig
+from evolver.hardware.interface import EffectorDriver, VialBaseModel
+from evolver.hardware.standard.base import SerialDeviceConfigBase
+from evolver.serial import SerialData
+
+
+class GenericPump(EffectorDriver):
+    """Pump control for evolver fluidics directly by pump ID.
+
+    This driver controls either or both of standard and IPP pumps according to the
+    arduino fluidics module. Pumps are indexed by pump ID (either position in array or
+    IPP pump number) and not vial, each must be controlled separately.
+
+    Specify the index of any IPP pumps via the config parameter ipp_pumps, this should
+    be an array of those pump IDs that are IPP. Please note that IPP pumps reserve 3
+    slots (1 for each solenoid), so if pump 0 is IPP, 1 and 2 cannot be assigned as
+    non-IPP pumps.
+    """
+
+    class Config(SerialDeviceConfigBase):
+        ipp_pumps: list[int] = Field([], description="Indexes of IPP mode pumps, per solenoid")
+
+    class Input(BaseConfig):
+        pump_id: int
+        flow_rate: float
+
+    @property
+    def serial(self):
+        return self.serial_conn or self.evolver.serial
+
+    def set(self, input):
+        self.proposal[input.pump_id] = input
+
+    def commit(self):
+        inputs = copy(self.committed)
+        inputs.update(self.proposal.items())
+        cmd = [b"--"] * self.slots
+        for pump, input in inputs.items():
+            if pump in self.ipp_pumps:
+                # TODO: calibation transform here. The IPP pumps should return array of
+                # hz values per solenoid number - containing 3 of them.
+                hz_a = [input.flow_rate] * 3
+                for solenoid, hz in enumerate(hz_a):
+                    # solenoid is 1-indexed on hardware
+                    cmd[pump * 3 + solenoid] = f"{hz}|{pump}|{solenoid+1}"
+            elif any(pump - i < 3 for i in self.ipp_pumps):
+                raise ValueError(f"pump slot {pump} reserved for IPP pump, cannot address as standard")
+            else:
+                # TODO: calibration transform here. The time_to_pump is the target variable
+                # where pump_interval would presumably be what the pump_interval was set to
+                # during calibration and is fixed post-calibration.
+                time_to_pump, pump_interval = (input.flow_rate, int(input.flow_rate))
+                cmd[pump] = f"{time_to_pump}|{pump_interval}".encode()
+        with self.serial as comm:
+            comm.communicate(SerialData(addr=self.addr, data=cmd))
+        self.committed = inputs
+
+
+class VialIEPump(EffectorDriver):
+    """Vial-based Influx-Efflux Pump driver.
+
+    Each pump in the array is either an influx (to bring liquid to the vial) or
+    efflux (to pull waste out of vial) or spare (unused). Flow rates can be configured
+    separately or as a single rate.
+
+    Configuration parameters ``influx_map`` and ``efflux_map`` can be used to specify
+    explicit mapping between vial and underlying pump_id (of :py:class:`GenericPump`),
+    which by default reserves the first 3rd of slots to influx, and second third to
+    efflux (remaining are spare).
+    """
+
+    class Config(GenericPump.Config):
+        influx_map: dict[int, int] | None = Field(None, description="map of vial to influx pump ID")
+        efflux_map: dict[int, int] | None = Field(None, description="map of vial to efflux pump ID")
+
+    class Input(VialBaseModel):
+        flow_rate_influx: float = Field(description="influx flow rate in ml/s")
+        flow_rate_efflux: float | None = Field(None, description="efflux flow rate in ml/s. Defaults to same as influx")
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        p_slots = self.slots * 3  # influx, efflux, spare (or 3 solenoids for IPP)
+        self._generic_pump = GenericPump(
+            addr=self.addr,
+            slots=p_slots,
+            serial=self.serial_conn,
+            ipp_pumps=self.ipp_pumps,
+            evolver=kwargs.get("evolver"),
+        )
+        self.influx_map = self.influx_map or {i: i for i in range(0, p_slots)}
+        self.efflux_map = self.efflux_map or {i: i + self.slots for i in range(0, p_slots)}
+
+    def commit(self):
+        for p in self.proposal.values():
+            if p.vial in self.vials:
+                if p.flow_rate_efflux is None:
+                    p.flow_rate_efflux = p.flow_rate_influx
+                self._generic_pump.set(GenericPump.Input(pump_id=self.influx_map[p.vial], flow_rate=p.flow_rate_influx))
+                self._generic_pump.set(GenericPump.Input(pump_id=self.efflux_map[p.vial], flow_rate=p.flow_rate_efflux))
+        self._generic_pump.commit()
+        self.committed = copy(self.proposal)

--- a/evolver/hardware/standard/pump.py
+++ b/evolver/hardware/standard/pump.py
@@ -32,7 +32,7 @@ class GenericPump(EffectorDriver):
         super().__init__(*args, **kwargs)
         if self.ipp_pumps is True:
             self.ipp_pumps = list(range(self.slots / 3))
-        elif not self.ipp_pumps:
+        elif self.ipp_pumps in (False, None):
             self.ipp_pumps = []
 
     @property

--- a/evolver/hardware/standard/pump.py
+++ b/evolver/hardware/standard/pump.py
@@ -22,11 +22,18 @@ class GenericPump(EffectorDriver):
     """
 
     class Config(SerialDeviceConfigBase):
-        ipp_pumps: list[int] = Field([], description="Indexes of IPP mode pumps, per solenoid")
+        ipp_pumps: bool | list[int] = Field(False, description="False (no IPP), True (all IPP), or list of IPP ids")
 
     class Input(BaseConfig):
         pump_id: int
         flow_rate: float
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.ipp_pumps is True:
+            self.ipp_pumps = list(range(self.slots / 3))
+        elif not self.ipp_pumps:
+            self.ipp_pumps = []
 
     @property
     def serial(self):

--- a/evolver/hardware/standard/stir.py
+++ b/evolver/hardware/standard/stir.py
@@ -1,0 +1,29 @@
+from copy import copy
+
+from pydantic import Field
+
+from evolver.hardware.interface import EffectorDriver, VialBaseModel
+from evolver.hardware.standard.base import SerialDeviceConfigBase
+from evolver.serial import SerialData
+
+
+class Stir(EffectorDriver):
+    class Config(SerialDeviceConfigBase):
+        stir_max: int = 98
+
+    class Input(VialBaseModel):
+        rate: int = Field(0, description="Stir rate setting")
+
+    @property
+    def serial(self):
+        return self.serial_conn or self.evolver.serial
+
+    def commit(self):
+        inputs = copy(self.committed)
+        inputs.update({v: i for v, i in self.proposal.items() if v in self.vials})
+        cmd = [b"0"] * self.slots
+        for v, i in inputs.items():
+            cmd[v] = str(i.rate).encode()
+        with self.serial as comm:
+            comm.communicate(SerialData(addr=self.addr, data=cmd))
+        self.committed = inputs

--- a/evolver/hardware/standard/stir.py
+++ b/evolver/hardware/standard/stir.py
@@ -15,7 +15,7 @@ class Stir(EffectorDriver):
     to the max rate available in arduino implementation.
     """
 
-    class Config(SerialDeviceConfigBase):
+    class Config(SerialDeviceConfigBase, EffectorDriver.Config):
         stir_max: int = 98
 
     class Input(VialBaseModel):

--- a/evolver/hardware/standard/stir.py
+++ b/evolver/hardware/standard/stir.py
@@ -8,6 +8,13 @@ from evolver.serial import SerialData
 
 
 class Stir(EffectorDriver):
+    """Stirrer with integer rate settings.
+
+    This implements the stirrer with very simple integer rate setting with no
+    calibration. There is a max setting guardrail, which by default corresponds
+    to the max rate available in arduino implementation.
+    """
+
     class Config(SerialDeviceConfigBase):
         stir_max: int = 98
 
@@ -23,7 +30,7 @@ class Stir(EffectorDriver):
         inputs.update({v: i for v, i in self.proposal.items() if v in self.vials})
         cmd = [b"0"] * self.slots
         for v, i in inputs.items():
-            cmd[v] = str(i.rate).encode()
+            cmd[v] = str(max(0, min(i.rate, self.stir_max))).encode()
         with self.serial as comm:
             comm.communicate(SerialData(addr=self.addr, data=cmd))
         self.committed = inputs

--- a/evolver/hardware/standard/tests/test_standard.py
+++ b/evolver/hardware/standard/tests/test_standard.py
@@ -113,7 +113,7 @@ class TestStir(SerialVialEffectorHardwareTestSuite):
             {"addr": "pump", "slots": 2},
             [
                 [
-                    VialIEPump.Input(vial=0, flow_rate_influx=1),
+                    VialIEPump.Input(vial=0, flow_rate_influx=1, flow_rate_efflux=1),
                     VialIEPump.Input(vial=1, flow_rate_influx=8, flow_rate_efflux=9),
                 ]
             ],

--- a/evolver/hardware/standard/tests/test_standard.py
+++ b/evolver/hardware/standard/tests/test_standard.py
@@ -2,6 +2,8 @@ import pytest
 
 from evolver.hardware.standard.led import LED
 from evolver.hardware.standard.od_sensor import ODSensor
+from evolver.hardware.standard.pump import VialIEPump
+from evolver.hardware.standard.stir import Stir
 from evolver.hardware.standard.temperature import Temperature
 from evolver.hardware.test_utils import SerialVialEffectorHardwareTestSuite, SerialVialSensorHardwareTestSuite
 
@@ -78,3 +80,51 @@ class TestTempEffectorMode(SerialVialEffectorHardwareTestSuite):
 )
 class TestLED(SerialVialEffectorHardwareTestSuite):
     driver = LED
+
+
+@pytest.mark.parametrize(
+    "config_params, values, serial_out",
+    [
+        (
+            {"addr": "stir", "slots": 2},
+            [[Stir.Input(vial=0, rate=8)], [Stir.Input(vial=1, rate=9)]],
+            [b"stirr,8,0,_!", b"stirr,8,9,_!"],
+        ),
+        (
+            {"addr": "stir", "vials": [1], "slots": 2},
+            [[Stir.Input(vial=0, rate=8)], [Stir.Input(vial=1, rate=9)]],
+            [b"stirr,0,0,_!", b"stirr,0,9,_!"],
+        ),
+    ],
+)
+class TestStir(SerialVialEffectorHardwareTestSuite):
+    driver = Stir
+
+
+@pytest.mark.parametrize(
+    "config_params, values, serial_out",
+    [
+        (
+            {"addr": "pump", "slots": 2},
+            [[VialIEPump.Input(vial=0, flow_rate_influx=1, flow_rate_efflux=2)]],
+            [b"pumpr,1.0|1,--,2.0|2,--,--,--,_!"],
+        ),
+        (
+            {"addr": "pump", "slots": 2},
+            [
+                [
+                    VialIEPump.Input(vial=0, flow_rate_influx=1),
+                    VialIEPump.Input(vial=1, flow_rate_influx=8, flow_rate_efflux=9),
+                ]
+            ],
+            [b"pumpr,1.0|1,8.0|8,1.0|1,9.0|9,--,--,_!"],
+        ),
+        (
+            {"addr": "pump", "ipp_pumps": [0, 1], "slots": 2, "influx_map": {0: 0}, "efflux_map": {0: 1}},
+            [[VialIEPump.Input(vial=0, flow_rate_influx=1, flow_rate_efflux=2)]],
+            [b"pumpr,1.0|0|1,1.0|0|2,1.0|0|3,2.0|1|1,2.0|1|2,2.0|1|3,_!"],
+        ),
+    ],
+)
+class TestPump(SerialVialEffectorHardwareTestSuite):
+    driver = VialIEPump

--- a/evolver/hardware/test_utils.py
+++ b/evolver/hardware/test_utils.py
@@ -15,10 +15,6 @@ def evolver_from_response_map(response_map):
     return Evolver(serial=serial_from_response_map(response_map))
 
 
-def _from_driver(driver, config, response_map):
-    return driver(**config, evolver=evolver_from_response_map(response_map))
-
-
 def _from_config_desc(driver, config, response_map):
     config_desc = ConfigDescriptor(classinfo=driver, config=config)
     return config_desc.create(non_config_kwargs={"evolver": evolver_from_response_map(response_map)})
@@ -58,11 +54,6 @@ class SerialVialSensorHardwareTestSuite:
     """
 
     driver: HardwareDriver = None
-
-    def test_expected_plain_instantiation(self, response_map, config_params, expected):
-        hw = _from_driver(self.driver, config_params, response_map)
-        hw.read()
-        assert hw.get() == expected
 
     def test_expected_create_from_config_desc(self, response_map, config_params, expected):
         hw = _from_config_desc(self.driver, config_params, response_map)
@@ -113,10 +104,6 @@ class SerialVialEffectorHardwareTestSuite:
             # in case we expect multiple of same, clear for next assertion
             del hw.evolver.serial.backend.hits_map[serial_out[pair_i]]
             assert hw.committed == expected_committed
-
-    def test_from_plain_instantiation(self, config_params, values, serial_out):
-        hw = _from_driver(self.driver, config_params, {})
-        self._load_and_check(hw, values, serial_out)
 
     def test_from_config_descriptor(self, config_params, values, serial_out):
         hw = _from_config_desc(self.driver, config_params, {})


### PR DESCRIPTION
Implement stirrer and pumps. 

In the case of stirrer this might not be correct in the case of calibration in that with calibration we might represent rate as RPM, but from the looks of their example experiment code the stirring is practically just used as some rate. Should be straightforward to update since this is a pretty simple effector.

For the pumps, the approach is to model a generic pump that is operates external to vials and indexes on pump number (48 of them), and supports a combination of standard and IPP pumps (these operate in different ways, but communicate to same underlying chip https://github.com/FYNCH-BIO/evolver-arduino/blob/master/SAMD21/RS485_FLUIDICS/RS485_FLUIDICS.ino), and then on top of this implement a per-vial influx/efflux setup that uses a generic device as a slave. A slave device rather than subclass is used due to different input types and mapping (2-to-1) for the vial driver.