### PR TITLE
add script to generate the openapi.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ cython_debug/
 
 # File system
 .DS_Store
+
+# temp - ignore any files named openapi.json
+openapi.json

--- a/README.md
+++ b/README.md
@@ -161,3 +161,10 @@ tox -e test exec -- python -m evolver.app.main
 You should then be able to visit the automatically generated API documentation in your local browser at
 https://localhost:8000/docs (or https://localhost:8000/redoc). From there you can experiment with sending
 data and reading from various endpoints (which will eventually be hooked up to a web user interface).
+
+### Generate openapi schema as a JSON
+To generate `openapi.json` in the project root run:
+
+```
+tox -e generate_openapi
+```

--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -35,7 +35,7 @@ app.state.evolver = None
 class EvolverConfigWithoutDefaults(Evolver.Config): ...
 
 
-@app.get("/")
+@app.get("/", operation_id="describe")
 async def describe_evolver():
     return {
         "config": app.state.evolver.config_model,
@@ -44,7 +44,7 @@ async def describe_evolver():
     }
 
 
-@app.get("/state")
+@app.get("/state", operation_id="state")
 async def get_state():
     return {
         "state": app.state.evolver.state,
@@ -52,23 +52,23 @@ async def get_state():
     }
 
 
-@app.post("/")
+@app.post("/", operation_id="update")
 async def update_evolver(config: EvolverConfigWithoutDefaults):
     app.state.evolver = Evolver.create(config)
     app.state.evolver.config_model.save(app_settings.CONFIG_FILE)
 
 
-@app.get("/schema/", response_model=SchemaResponse)
+@app.get("/schema/", response_model=SchemaResponse, operation_id="schema")
 async def get_schema(classinfo: ImportString | None = evolver.util.fully_qualified_name(Evolver)) -> SchemaResponse:
     return SchemaResponse(classinfo=classinfo)
 
 
-@app.get("/history/{name}")
+@app.get("/history/{name}", operation_id="history")
 async def get_history(name: str):
     return app.state.evolver.history.get(name)
 
 
-@app.get("/healthz")
+@app.get("/healthz", operation_id="healthcheck")
 async def healthz():
     return {"message": f"Running '{__project__}' ver: '{__version__}'"}
 

--- a/scripts/generate_openapi.py
+++ b/scripts/generate_openapi.py
@@ -1,0 +1,18 @@
+import json
+
+from fastapi.openapi.utils import get_openapi
+
+from evolver.app.main import app
+
+# Generate OpenAPI schema
+openapi_schema = get_openapi(
+    title=app.title,
+    version=app.version,
+    openapi_version=app.openapi_version,
+    description=app.description,
+    routes=app.routes,
+)
+
+# Save the schema to a JSON file
+with open("openapi.json", "w") as f:
+    json.dump(openapi_schema, f, indent=2)

--- a/tox.ini
+++ b/tox.ini
@@ -61,3 +61,10 @@ deps =
     -r requirements/build.txt
 commands =
     python -m build
+
+[testenv:generate_openapi]
+description = build the openapi schema as a json file 
+deps =
+    -r requirements/prd.txt
+commands =
+    python scripts/generate_openapi.py


### PR DESCRIPTION
Required if this pipeline for publishing the `evolver-ng-ts-client` npm package is adopted.

![evolver-client-structure](https://github.com/user-attachments/assets/4ee2b468-1a3c-4eb5-a8c5-bbe466c209ca)


We're actually not likely to do this. Instead the generated `openapi.json`will likely be just copied into a `/ui` dir in this project where the frontend will live. The frontend build process (npm) will take care of generating the client from there.