### PR TITLE
add id

### DIFF
--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -44,6 +44,7 @@ async def describe_evolver():
         "config": app.state.evolver.config_model,
         "state": app.state.evolver.state,
         "last_read": app.state.evolver.last_read,
+        "id": app.state.evolver.id,
     }
 
 

--- a/evolver/app/tests/test_app.py
+++ b/evolver/app/tests/test_app.py
@@ -40,7 +40,7 @@ class TestApp:
     def test_evolver_app_default_config_dump_endpoint(self, app_client):
         response = app_client.get("/")
         assert response.status_code == 200
-        assert sorted(response.json().keys()) == ["config", "last_read", "state"]
+        assert sorted(response.json().keys()) == ["config", "id", "last_read", "state"]
 
     def test_EvolverConfigWithoutDefaults(self):
         EvolverConfigWithoutDefaults.model_validate(Evolver.Config().model_dump())

--- a/evolver/device.py
+++ b/evolver/device.py
@@ -1,4 +1,5 @@
 import time
+import uuid
 from collections import defaultdict
 
 from evolver.base import BaseInterface, ConfigDescriptor
@@ -28,6 +29,7 @@ class Evolver(BaseInterface):
         interval: int = settings.DEFAULT_LOOP_INTERVAL
 
     def __init__(self, *args, **kwargs):
+        self.id = uuid.uuid4().hex[:6]
         self.last_read = defaultdict(lambda: int(-1))
         super().__init__(*args, evolver=self, **kwargs)
 


### PR DESCRIPTION
Add an id field to the evolver and return it in the `describe` response.

This gives the frontend a stable identifier for the evolver(s) it has connected to.