### PR TITLE
Rename Transformer.Config.coefficients -> parameters

### DIFF
--- a/calibration_files/default_od135_calibration_config.yml
+++ b/calibration_files/default_od135_calibration_config.yml
@@ -5,7 +5,7 @@ config:
     '0':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 15.361409079929091
         - -0.0002831883405076742
         - -0.00013797258278699858
@@ -16,7 +16,7 @@ config:
     '1':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 22.63726720724552
         - -0.0004370231824921231
         - -0.00023043798773755397
@@ -27,7 +27,7 @@ config:
     '10':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 11.75891601924426
         - -0.00021633970317384965
         - -7.49164890272995e-05
@@ -38,7 +38,7 @@ config:
     '11':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 4.4936731879203675
         - 2.57706684794889e-05
         - -2.3832773816480295e-05
@@ -49,7 +49,7 @@ config:
     '12':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - -1.7190515043753891
         - 0.00014976769565351922
         - 8.252131951504111e-05
@@ -60,7 +60,7 @@ config:
     '13':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 13.258331969341269
         - -0.00024908079046834025
         - -9.004282976350286e-05
@@ -71,7 +71,7 @@ config:
     '14':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 10.618712830534315
         - -0.00016341885151076769
         - -7.464942340711304e-05
@@ -82,7 +82,7 @@ config:
     '15':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 10.287640032183935
         - -0.000177467381678139
         - -8.46496264716175e-05
@@ -93,7 +93,7 @@ config:
     '2':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 18.34011938793681
         - -0.0003525947843818188
         - -0.00014946331924706687
@@ -104,7 +104,7 @@ config:
     '3':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 16.008353863500833
         - -0.0003391779685038511
         - -0.0001635718556123535
@@ -115,7 +115,7 @@ config:
     '4':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 9.36904544957634
         - -0.00015260830694862042
         - -7.164824223484227e-05
@@ -126,7 +126,7 @@ config:
     '5':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 10.472760151905074
         - -0.00018466851836629138
         - -6.119933929253222e-05
@@ -137,7 +137,7 @@ config:
     '6':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 25.442365651612544
         - -0.0005539681005625055
         - -0.00023227436309533378
@@ -148,7 +148,7 @@ config:
     '7':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 11.925707187386395
         - -0.00019218878643415444
         - -8.523919667988522e-05
@@ -159,7 +159,7 @@ config:
     '8':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - -1.1930439169259741
         - 0.00019291067474260757
         - 6.834569839594361e-05
@@ -170,7 +170,7 @@ config:
     '9':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 9.053869831378954
         - -0.00010539808368912342
         - -5.1325293716096055e-05

--- a/calibration_files/default_od90_calibration_config.yml
+++ b/calibration_files/default_od90_calibration_config.yml
@@ -5,7 +5,7 @@ config:
     '0':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 29432.135381591164
         - 63297.4871054736
         - 1.7150095143793729
@@ -14,7 +14,7 @@ config:
     '1':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 35445.377906931986
         - 61445.792654394194
         - 1.5473287494441013
@@ -23,7 +23,7 @@ config:
     '10':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 35912.92989079456
         - 60275.18875897503
         - 1.461784408860302
@@ -32,7 +32,7 @@ config:
     '11':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 36522.402150300324
         - 67681.75878077731
         - 1.597366788005353
@@ -41,7 +41,7 @@ config:
     '12':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 37050.49276296644
         - 61215.49532388249
         - 1.5060611794060363
@@ -50,7 +50,7 @@ config:
     '13':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 36468.29761820028
         - 60206.72567203502
         - 1.462103395122217
@@ -59,7 +59,7 @@ config:
     '14':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 36086.07039746199
         - 60455.664048370796
         - 1.523701869786409
@@ -68,7 +68,7 @@ config:
     '15':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 23986.243022581086
         - 62232.0236138627
         - 1.6173003557752983
@@ -77,7 +77,7 @@ config:
     '2':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 24889.062264794884
         - 69310.29168562933
         - 2.014342476164939
@@ -86,7 +86,7 @@ config:
     '3':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 23916.680312808683
         - 58765.9600006942
         - 1.561024584487947
@@ -95,7 +95,7 @@ config:
     '4':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 27844.606781703813
         - 58572.43773197114
         - 1.5436247829476943
@@ -104,7 +104,7 @@ config:
     '5':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 34478.54917482691
         - 58886.86400938548
         - 1.472288432483906
@@ -113,7 +113,7 @@ config:
     '6':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 39277.85273472174
         - 60473.68758496221
         - 1.4345691798956386
@@ -122,7 +122,7 @@ config:
     '7':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 38548.936373099496
         - 58469.81067190847
         - 1.4709390800919195
@@ -131,7 +131,7 @@ config:
     '8':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 41401.650197498064
         - 58709.44304424908
         - 1.511822472565226
@@ -140,7 +140,7 @@ config:
     '9':
       classinfo: evolver.calibration.standard.sigmoid.SigmoidFitTransformer
       config:
-        coefficients:
+        parameters:
         - 38054.82576336855
         - 58525.98048596561
         - 1.5493230357372643

--- a/calibration_files/default_temperature_calibration_config.yml
+++ b/calibration_files/default_temperature_calibration_config.yml
@@ -4,112 +4,112 @@ config:
     '0':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 82.81905722355664
         - -0.028115295477514426
         created: '2019-02-01T00:00:00'
     '1':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 85.124125786813
         - -0.02928665515959123
         created: '2019-02-01T00:00:00'
     '10':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 83.1242161406514
         - -0.0285208197069001
         created: '2019-02-01T00:00:00'
     '11':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 84.0801874593112
         - -0.0288807561658323
         created: '2019-02-01T00:00:00'
     '12':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 84.43090022635461
         - -0.0288818454124514
         created: '2019-02-01T00:00:00'
     '13':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 81.78219292896019
         - -0.027770396100254592
         created: '2019-02-01T00:00:00'
     '14':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 84.88996813953604
         - -0.029212064588407444
         created: '2019-02-01T00:00:00'
     '15':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 84.92407412643684
         - -0.0291848685550686
         created: '2019-02-01T00:00:00'
     '2':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 84.2472187106695
         - -0.028920934578440128
         created: '2019-02-01T00:00:00'
     '3':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 85.18980458798858
         - -0.029227840711423782
         created: '2019-02-01T00:00:00'
     '4':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 84.22198012669016
         - -0.02875141292593247
         created: '2019-02-01T00:00:00'
     '5':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 85.49655675887921
         - -0.02953115180372555
         created: '2019-02-01T00:00:00'
     '6':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 83.97313381240193
         - -0.028731553968809102
         created: '2019-02-01T00:00:00'
     '7':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 81.64346835743908
         - -0.027620071465360534
         created: '2019-02-01T00:00:00'
     '8':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 83.82843934811194
         - -0.028809619926954234
         created: '2019-02-01T00:00:00'
     '9':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 86.43200167220084
         - -0.03001347682908921
         created: '2019-02-01T00:00:00'
@@ -117,112 +117,112 @@ config:
     '0':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 82.81905722355664
         - -0.028115295477514426
         created: '2019-02-01T00:00:00'
     '1':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 85.124125786813
         - -0.02928665515959123
         created: '2019-02-01T00:00:00'
     '10':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 83.1242161406514
         - -0.0285208197069001
         created: '2019-02-01T00:00:00'
     '11':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 84.0801874593112
         - -0.0288807561658323
         created: '2019-02-01T00:00:00'
     '12':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 84.43090022635461
         - -0.0288818454124514
         created: '2019-02-01T00:00:00'
     '13':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 81.78219292896019
         - -0.027770396100254592
         created: '2019-02-01T00:00:00'
     '14':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 84.88996813953604
         - -0.029212064588407444
         created: '2019-02-01T00:00:00'
     '15':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 84.92407412643684
         - -0.0291848685550686
         created: '2019-02-01T00:00:00'
     '2':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 84.2472187106695
         - -0.028920934578440128
         created: '2019-02-01T00:00:00'
     '3':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 85.18980458798858
         - -0.029227840711423782
         created: '2019-02-01T00:00:00'
     '4':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 84.22198012669016
         - -0.02875141292593247
         created: '2019-02-01T00:00:00'
     '5':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 85.49655675887921
         - -0.02953115180372555
         created: '2019-02-01T00:00:00'
     '6':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 83.97313381240193
         - -0.028731553968809102
         created: '2019-02-01T00:00:00'
     '7':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 81.64346835743908
         - -0.027620071465360534
         created: '2019-02-01T00:00:00'
     '8':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 83.82843934811194
         - -0.028809619926954234
         created: '2019-02-01T00:00:00'
     '9':
       classinfo: evolver.calibration.standard.polyfit.LinearTransformer
       config:
-        coefficients:
+        parameters:
         - 86.43200167220084
         - -0.03001347682908921
         created: '2019-02-01T00:00:00'

--- a/evolver/calibration/standard/curve_fit.py
+++ b/evolver/calibration/standard/curve_fit.py
@@ -8,7 +8,7 @@ from evolver.calibration.interface import IndependentVialBasedCalibrator, Transf
 
 class CurveFitTransformer(Transformer, ABC):
     class Config(Transformer.Config):
-        coefficients: list[float] = Field(description="Transformer parameters")
+        parameters: list[float] = Field(description="Transformer parameters")
 
     @classmethod
     @abstractmethod
@@ -29,14 +29,14 @@ class CurveFitTransformer(Transformer, ABC):
         See https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.curve_fit.html
         """
         new_parameters, *_other = curve_fit(cls.func_from, x, y, *args, **kwargs)
-        config = cls.Config.model_validate(dict(coefficients=new_parameters))
+        config = cls.Config.model_validate(dict(parameters=new_parameters))
         return config
 
     def convert_to(self, x):
-        return self.func_to(x, *self.coefficients)
+        return self.func_to(x, *self.parameters)
 
     def convert_from(self, y):
-        return self.func_from(y, *self.coefficients)
+        return self.func_from(y, *self.parameters)
 
 
 class IndependentVialBasedCurveFitCalibrator(IndependentVialBasedCalibrator):

--- a/evolver/calibration/standard/polyfit.py
+++ b/evolver/calibration/standard/polyfit.py
@@ -11,28 +11,28 @@ from evolver.settings import settings
 class PolyFitTransformer(Transformer):
     class Config(Transformer.Config):
         degree: int = Field(ge=0, description="Polynomial degree.")
-        coefficients: list[float] = Field(min_length=1, description="Polynomial coefficients.")
+        parameters: list[float] = Field(min_length=1, description="Polynomial coefficients.")
 
         @model_validator(mode="after")
-        def check_coefficients_length(self) -> Self:
-            if len(self.coefficients) - 1 != self.degree:
-                raise ValueError(f"Degree={self.degree} but {len(self.coefficients)} coefficients given.")
+        def check_parameters_length(self) -> Self:
+            if len(self.parameters) - 1 != self.degree:
+                raise ValueError(f"Degree={self.degree} but {len(self.parameters)} parameters given.")
             return self
 
     @classmethod
     def fit(cls, x, y, deg, *args, **kwargs):
-        new_coefficients = poly.polyfit(x, y, deg, *args, **kwargs)
-        config = cls.Config.model_validate(dict(coefficients=new_coefficients))
+        new_parameters = poly.polyfit(x, y, deg, *args, **kwargs)
+        config = cls.Config.model_validate(dict(parameters=new_parameters))
         return config
 
     def refit(self, x, y, *args, **kwargs):
         return super().refit(x, y, self.degree, *args, **kwargs)
 
     def convert_to(self, x):
-        return poly.polyval(x, self.coefficients)
+        return poly.polyval(x, self.parameters)
 
     def convert_from(self, y):
-        return (poly.Polynomial(self.coefficients) - y).roots()
+        return (poly.Polynomial(self.parameters) - y).roots()
 
 
 class LinearTransformer(PolyFitTransformer):

--- a/evolver/calibration/standard/tests/test_fitting.py
+++ b/evolver/calibration/standard/tests/test_fitting.py
@@ -23,13 +23,13 @@ class TestLinearTransformer:
         x, y, c = mock_linear_data
         config = LinearTransformer.fit(x, y)
         assert config.degree == 1
-        assert len(config.coefficients) == 2
-        assert config.coefficients == pytest.approx(c)
+        assert len(config.parameters) == 2
+        assert config.parameters == pytest.approx(c)
         assert config.created - datetime.now() < timedelta(seconds=5)
 
     def test_convert(self, mock_linear_data):
         x, y, c = mock_linear_data
-        obj = LinearTransformer(coefficients=c)
+        obj = LinearTransformer(parameters=c)
         x_prime = 50
         y_prime = obj.convert_to(x_prime)
         assert y_prime == pytest.approx(c[0] + x_prime * c[1])
@@ -37,15 +37,15 @@ class TestLinearTransformer:
 
     def test_refit(self, mock_linear_data):
         x, y, c = mock_linear_data
-        obj = LinearTransformer(coefficients=c)
+        obj = LinearTransformer(parameters=c)
         old_config = obj.config_model
-        assert obj.coefficients == c
+        assert obj.parameters == c
         c_prime = [c[0] + 2, c[1] + 3]
         y_prime = c_prime[0] + x * c_prime[1]
         new_config = obj.refit(x, y_prime)
         assert new_config.created > old_config.created
-        assert new_config.coefficients != old_config.coefficients
-        assert obj.coefficients == pytest.approx(c_prime)
+        assert new_config.parameters != old_config.parameters
+        assert obj.parameters == pytest.approx(c_prime)
 
         x_prime = 50
         y_prime = obj.convert_to(x_prime)
@@ -55,24 +55,24 @@ class TestLinearTransformer:
     def test_validation(self, mock_linear_data):
         x, y, c = mock_linear_data
         with pytest.raises(ValidationError, match="Input should be less than or equal to 1"):
-            LinearTransformer.Config(degree=2, coefficients=c)
+            LinearTransformer.Config(degree=2, parameters=c)
 
         with pytest.raises(ValidationError):
-            LinearTransformer.Config(degree=1, coefficients=[1, 2, 3])
+            LinearTransformer.Config(degree=1, parameters=[1, 2, 3])
 
 
 class TestLinearCalibrator:
     def test_calibration_procedure(self, mock_linear_data, tmp_calibration_dir):  # noqa: F811
         x, y, c = mock_linear_data
-        obj = LinearCalibrator(input_transformer=LinearTransformer(coefficients=c))
+        obj = LinearCalibrator(input_transformer=LinearTransformer(parameters=c))
         old_config = obj.input_transformer.config_model
         c_prime = [c[0] + 2, c[1] + 3]
         y_prime = c_prime[0] + x * c_prime[1]
         new_config = obj.run_calibration_procedure(dict(input_transformer=(x, y_prime)))["input_transformer"]
 
         assert new_config.created > old_config.created
-        assert new_config.coefficients != old_config.coefficients
-        assert new_config.coefficients == pytest.approx(c_prime)
+        assert new_config.parameters != old_config.parameters
+        assert new_config.parameters == pytest.approx(c_prime)
 
         x_prime = 50
         y_prime = obj.input_transformer.convert_to(x_prime)


### PR DESCRIPTION
Resolves #170

This is just a replace-all on ``coefficients`` -> ``parameters``. Only the config description for polyfit keeps a ref to coefficients.