### PR TITLE
Removing sampling for schema in history query

### DIFF
--- a/evolver/history/standard.py
+++ b/evolver/history/standard.py
@@ -82,6 +82,8 @@ class HistoryServer(History):
                 read_json('{self.history_dir}/*/history.json',
                     format='newline_delimited',
                     ignore_errors=true,
+                    columns={{timestamp: 'double', name: 'varchar', data: 'varchar'}},
+                    auto_detect=false,
                     hive_partitioning=true)
                 """  # nosec: B608
             )
@@ -108,7 +110,7 @@ class HistoryServer(History):
             try:
                 # json only allows string keys, might want to revisit the assumptions
                 # here, and/or have a more concrete vial-data container
-                row_data = {int(k): v for k, v in row_data.items()}
+                row_data = {int(k): v for k, v in json.loads(row_data).items()}
             except Exception:
                 pass
             try:


### PR DESCRIPTION
This makes history quicker by removing the need to sample files to infer schema. Latency noticeably decreases, but still might want to keep a buffer in memory.

Related to #183, but may only partially resolve