### PR TITLE
small fix to tox check style to match what format would change

### DIFF
--- a/evolver/app/routers/hardware.py
+++ b/evolver/app/routers/hardware.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 from fastapi import APIRouter, Body, HTTPException, Path, Request
 from pydantic import BaseModel
 
-from evolver.app.exceptions import HardwareNotFoundError, CalibratorNotFoundError
+from evolver.app.exceptions import CalibratorNotFoundError, HardwareNotFoundError
 from evolver.hardware.interface import HardwareDriver
 
 router = APIRouter(prefix="/hardware", tags=["hardware"], responses={404: {"description": "Not found"}})

--- a/evolver/app/tests/test_calibration.py
+++ b/evolver/app/tests/test_calibration.py
@@ -1,13 +1,11 @@
-from evolver.calibration.interface import TemperatureCalibrator
-from evolver.tests.conftest import tmp_calibration_dir  # noqa: F401
+from fastapi.testclient import TestClient
 
 from evolver.app.main import app
-from evolver.device import Evolver
 from evolver.calibration.demo import NoOpCalibrator
+from evolver.calibration.interface import TemperatureCalibrator
+from evolver.device import Evolver
 from evolver.hardware.demo import NoOpSensorDriver
-
-
-from fastapi.testclient import TestClient
+from evolver.tests.conftest import tmp_calibration_dir  # noqa: F401
 
 
 class TestCalibration:

--- a/evolver/app/tests/test_hardware.py
+++ b/evolver/app/tests/test_hardware.py
@@ -1,12 +1,10 @@
-from evolver.tests.conftest import tmp_calibration_dir  # noqa: F401
+from fastapi.testclient import TestClient
 
 from evolver.app.main import app
-from evolver.device import Evolver
 from evolver.calibration.demo import NoOpCalibrator
+from evolver.device import Evolver
 from evolver.hardware.demo import NoOpSensorDriver
-
-
-from fastapi.testclient import TestClient
+from evolver.tests.conftest import tmp_calibration_dir  # noqa: F401
 
 
 class TestHardware:

--- a/evolver/calibration/actions.py
+++ b/evolver/calibration/actions.py
@@ -1,6 +1,6 @@
-from typing import Dict, Any
-from copy import deepcopy
 from abc import ABC, abstractmethod
+from copy import deepcopy
+from typing import Any, Dict
 
 
 class CalibrationAction(ABC):

--- a/evolver/calibration/interface.py
+++ b/evolver/calibration/interface.py
@@ -1,7 +1,7 @@
 import datetime
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from pydantic import Field, PastDatetime
 
@@ -14,14 +14,14 @@ from evolver.base import (
     TimeStamp,
     _BaseConfig,
 )
-from evolver.calibration.procedure import (
-    CalibrationProcedure,
-)
 from evolver.calibration.actions import (
     DisplayInstructionAction,
     VialTempCalculateFitAction,
     VialTempRawVoltageAction,
     VialTempReferenceValueAction,
+)
+from evolver.calibration.procedure import (
+    CalibrationProcedure,
 )
 from evolver.settings import settings
 

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ deps =
     -r requirements/test.txt
 commands =
     ruff format . --check {posargs}
+    ruff check --select I . {posargs}
     ruff check . {posargs}
 
 [testenv:check-security]
@@ -63,7 +64,7 @@ commands =
     python -m build
 
 [testenv:generate_openapi]
-description = build the openapi schema as a json file 
+description = build the openapi schema as a json file
 deps =
     -r requirements/prd.txt
 commands =


### PR DESCRIPTION
There was a mismatch in `check-style` and `format`, where `check-style` passed while format changed some things even in passing case. This means that some things could (and did) get missed which create confusing changes for subsequent PRs.

Only one line is relevent, `tox.ini:17`, everything else is a fix for the style as a result