### PR TITLE
Iainland/calibration actions

### DIFF
--- a/evolver/app/routers/hardware.py
+++ b/evolver/app/routers/hardware.py
@@ -1,5 +1,6 @@
 from typing import Any, Dict, List
 
+import pydantic
 from fastapi import APIRouter, Body, HTTPException, Path, Request
 from pydantic import BaseModel
 
@@ -63,7 +64,7 @@ def start_calibration_procedure(
 
 
 # Get available actions for the calibration procedure
-@router.post("/{hardware_name}/calibrator/actions")
+@router.get("/{hardware_name}/calibrator/actions")
 def get_calibrator_actions(hardware_name: str, request: Request):
     hardware_instance = get_hardware_instance(request, hardware_name)
     calibrator = hardware_instance.calibrator
@@ -92,7 +93,12 @@ def dispatch_calibrator_action(request: Request, hardware_name: str = Path(...),
     if not action_to_dispatch:
         raise HTTPException(status_code=404, detail=f"Action '{action['action_name']}' not found")
 
-    new_state = calibration_procedure.dispatch(action_to_dispatch, action["payload"])
+    try:
+        payload = action["payload"]
+        new_state = calibration_procedure.dispatch(action_to_dispatch, payload)
+    except pydantic.ValidationError as e:
+        raise HTTPException(status_code=422, detail=f"Invalid payload: {e.errors()}")
+
     return {"state": new_state}
 
 

--- a/evolver/app/tests/test_calibration.py
+++ b/evolver/app/tests/test_calibration.py
@@ -1,11 +1,10 @@
 from fastapi.testclient import TestClient
-
+from evolver.calibration.standard.calibrators.temperature import TemperatureCalibrator
+from evolver.tests.conftest import tmp_calibration_dir  # noqa: F401
 from evolver.app.main import app
 from evolver.calibration.demo import NoOpCalibrator
-from evolver.calibration.interface import TemperatureCalibrator
 from evolver.device import Evolver
 from evolver.hardware.demo import NoOpSensorDriver
-from evolver.tests.conftest import tmp_calibration_dir  # noqa: F401
 
 
 class TestCalibration:
@@ -111,7 +110,7 @@ def test_temperature_calibration_procedure_actions():
     assert response.status_code == 200
 
     # Verify the available actions in the calibration procedure
-    actions_response = client.post("hardware/temp/calibrator/actions")
+    actions_response = client.get("hardware/temp/calibrator/actions")
     assert actions_response.status_code == 200
     expected_actions = [
         {"name": action.name, "description": action.description}

--- a/evolver/app/tests/test_calibration.py
+++ b/evolver/app/tests/test_calibration.py
@@ -1,10 +1,11 @@
 from fastapi.testclient import TestClient
-from evolver.calibration.standard.calibrators.temperature import TemperatureCalibrator
-from evolver.tests.conftest import tmp_calibration_dir  # noqa: F401
+
 from evolver.app.main import app
 from evolver.calibration.demo import NoOpCalibrator
+from evolver.calibration.standard.calibrators.temperature import TemperatureCalibrator
 from evolver.device import Evolver
 from evolver.hardware.demo import NoOpSensorDriver
+from evolver.tests.conftest import tmp_calibration_dir  # noqa: F401
 
 
 class TestCalibration:

--- a/evolver/app/tests/test_calibration.py
+++ b/evolver/app/tests/test_calibration.py
@@ -156,7 +156,7 @@ def test_dispatch_temperature_calibration_action():
     assert response.status_code == 200
 
     # Now we will dispatch an action to the calibrator
-    action_payload = {"action_name": "Vial_0_Temp_Reference_Value_Action", "payload": {"reference_value": 25.0}}
+    action_payload = {"action_name": "Vial_0_Temp_Reference_Value_Action", "payload": {"temperature": 25.0}}
 
     # Dispatch the action
     dispatch_response = client.post("/hardware/temp/calibrator/dispatch", json=action_payload)

--- a/evolver/calibration/actions.py
+++ b/evolver/calibration/actions.py
@@ -15,16 +15,13 @@ class CalibrationAction(ABC):
 
 class DisplayInstructionAction(CalibrationAction):
     class UserInput(pydantic.BaseModel):
-        confirmation: bool = pydantic.Field(True, description="Confirm that the instruction has been completed")
+        pass
 
     def __init__(self, description: str, name: str):
         self.description = description
         self.name = name
 
     def execute(self, state: Dict[str, Any], payload: UserInput = None) -> Dict[str, Any]:
-        if not payload.confirmation:
-            raise ValueError("Confirmation is required to proceed")
-
         return state.copy()
 
 

--- a/evolver/calibration/interface.py
+++ b/evolver/calibration/interface.py
@@ -14,19 +14,10 @@ from evolver.base import (
     TimeStamp,
     _BaseConfig,
 )
-from evolver.calibration.actions import (
-    DisplayInstructionAction,
-    VialTempCalculateFitAction,
-    VialTempRawVoltageAction,
-    VialTempReferenceValueAction,
-)
-from evolver.calibration.procedure import (
-    CalibrationProcedure,
-)
 from evolver.settings import settings
 
 if TYPE_CHECKING:
-    from evolver.hardware.interface import HardwareDriver
+    pass
 
 
 class Status(TimeStamp):
@@ -198,55 +189,3 @@ class IndependentVialBasedCalibrator(Calibrator, ABC):
         output_transformer: dict[int, ConfigDescriptor | Transformer | None] | None = None
 
     def initialize_calibration_procedure(self, *args, **kwargs): ...
-
-
-# Example calibrator implementation to match existing temperature calibration flow.
-class TemperatureCalibrator(Calibrator):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.state = {"selected_vials": []}
-
-    def initialize_calibration_procedure(
-        self,
-        selected_hardware: "HardwareDriver",
-        selected_vials: list[int],
-        evolver=None,
-        *args,
-        **kwargs,
-    ):
-        # TODO: integrate self.state with self.CalibrationData, see Arik & Iain for context.
-        self.state["selected_vials"] = selected_vials
-
-        calibration_procedure = CalibrationProcedure("Temperature Calibration")
-        calibration_procedure.add_action(
-            DisplayInstructionAction(description="Fill each vial with 15ml water", name="Fill_Vials_With_Water")
-        )
-        for vial in self.state["selected_vials"]:
-            calibration_procedure.add_action(
-                VialTempReferenceValueAction(
-                    hardware=selected_hardware,
-                    vial_idx=vial,
-                    description=f"Use a thermometer to measure the real temperature in the vial {vial}",
-                    name=f"Vial_{vial}_Temp_Reference_Value_Action",
-                )
-            )
-            calibration_procedure.add_action(
-                VialTempRawVoltageAction(
-                    hardware=selected_hardware,
-                    vial_idx=vial,
-                    description=f"The hardware will now read the raw voltage from the temperature sensor, vial {vial}",
-                    name=f"Vial_{vial}_Temp_Raw_Voltage_Action",
-                )
-            )
-
-        # Add a final step to calculate the fit.
-        for vial in self.state["selected_vials"]:
-            calibration_procedure.add_action(
-                VialTempCalculateFitAction(
-                    hardware=selected_hardware,
-                    vial_idx=vial,
-                    description="Use the real and raw values that have been collected to calculate the fit for the temperature sensor",
-                    name=f"Vial_{vial}_Temp_Calculate_Fit_Action",
-                )
-            )
-        self.calibration_procedure = calibration_procedure

--- a/evolver/calibration/procedure.py
+++ b/evolver/calibration/procedure.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any
+from typing import Any, Dict
 
 from evolver.calibration.actions import CalibrationAction
 

--- a/evolver/calibration/procedure.py
+++ b/evolver/calibration/procedure.py
@@ -1,3 +1,8 @@
+from typing import Dict, Any
+
+from evolver.calibration.actions import CalibrationAction
+
+
 class CalibrationProcedure:
     def __init__(self, name: str):
         self.name = name
@@ -8,7 +13,6 @@ class CalibrationProcedure:
         # The procedure state is updated immutably, so that the state of the procedure is always consistent.
         self.actions = []
         self.state = {}  # Holds the current state of calibration, when the procedure is done this is copied to the Calibrator state.
-        # TODO: undo/redo stack of states. This allows undo/redo functionality
         # TODO: persist state to after each action to the Calibrator.CalibrationData data structure.(see Arik for details)
 
     def add_action(self, step):
@@ -17,7 +21,8 @@ class CalibrationProcedure:
     def get_actions(self):
         return self.actions
 
-    def dispatch(self, action, payload):
-        # Execute the action and update the state
+    def dispatch(self, action: CalibrationAction, payload: Dict[str, Any]) -> Dict[str, Any]:
+        if payload is not None:
+            payload = action.UserInput(**payload)
         self.state = action.execute(self.state, payload)
         return self.state

--- a/evolver/calibration/standard/calibrators/temperature.py
+++ b/evolver/calibration/standard/calibrators/temperature.py
@@ -1,8 +1,8 @@
 from evolver.calibration.actions import (
     DisplayInstructionAction,
-    VialTempReferenceValueAction,
-    VialTempRawVoltageAction,
     VialTempCalculateFitAction,
+    VialTempRawVoltageAction,
+    VialTempReferenceValueAction,
 )
 from evolver.calibration.interface import Calibrator
 from evolver.calibration.procedure import CalibrationProcedure

--- a/evolver/calibration/standard/calibrators/temperature.py
+++ b/evolver/calibration/standard/calibrators/temperature.py
@@ -1,0 +1,59 @@
+from evolver.calibration.actions import (
+    DisplayInstructionAction,
+    VialTempReferenceValueAction,
+    VialTempRawVoltageAction,
+    VialTempCalculateFitAction,
+)
+from evolver.calibration.interface import Calibrator
+from evolver.calibration.procedure import CalibrationProcedure
+
+
+class TemperatureCalibrator(Calibrator):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.state = {"selected_vials": []}
+
+    def initialize_calibration_procedure(
+        self,
+        selected_hardware: "HardwareDriver",
+        selected_vials: list[int],
+        evolver=None,
+        *args,
+        **kwargs,
+    ):
+        # TODO: integrate self.state with self.CalibrationData, see Arik & Iain for context.
+        self.state["selected_vials"] = selected_vials
+
+        calibration_procedure = CalibrationProcedure("Temperature Calibration")
+        calibration_procedure.add_action(
+            DisplayInstructionAction(description="Fill each vial with 15ml water", name="Fill_Vials_With_Water")
+        )
+        for vial in self.state["selected_vials"]:
+            calibration_procedure.add_action(
+                VialTempReferenceValueAction(
+                    hardware=selected_hardware,
+                    vial_idx=vial,
+                    description=f"Use a thermometer to measure the real temperature in the vial {vial}",
+                    name=f"Vial_{vial}_Temp_Reference_Value_Action",
+                )
+            )
+            calibration_procedure.add_action(
+                VialTempRawVoltageAction(
+                    hardware=selected_hardware,
+                    vial_idx=vial,
+                    description=f"The hardware will now read the raw voltage from the temperature sensor, vial {vial}",
+                    name=f"Vial_{vial}_Temp_Raw_Voltage_Action",
+                )
+            )
+
+        # Add a final step to calculate the fit.
+        for vial in self.state["selected_vials"]:
+            calibration_procedure.add_action(
+                VialTempCalculateFitAction(
+                    hardware=selected_hardware,
+                    vial_idx=vial,
+                    description="Use the real and raw values that have been collected to calculate the fit for the temperature sensor",
+                    name=f"Vial_{vial}_Temp_Calculate_Fit_Action",
+                )
+            )
+        self.calibration_procedure = calibration_procedure

--- a/evolver/calibration/standard/calibrators/temperature.py
+++ b/evolver/calibration/standard/calibrators/temperature.py
@@ -6,6 +6,7 @@ from evolver.calibration.actions import (
 )
 from evolver.calibration.interface import Calibrator
 from evolver.calibration.procedure import CalibrationProcedure
+from evolver.hardware.interface import HardwareDriver
 
 
 class TemperatureCalibrator(Calibrator):
@@ -15,7 +16,7 @@ class TemperatureCalibrator(Calibrator):
 
     def initialize_calibration_procedure(
         self,
-        selected_hardware: "HardwareDriver",
+        selected_hardware: HardwareDriver,
         selected_vials: list[int],
         evolver=None,
         *args,


### PR DESCRIPTION
This PR:
- adds a `UserInput` pydantic model to the calibration actions
- refactors the `TemperatureCalibrator` into `calibration/standard/calibrators/temperature.py`
- parses the `UserInput` in the dispatch method of CalibrationProcedure.

misc cleanup
- the list actions endpoint can be a `get`
