### PR TITLE
[history] Add in-memory buffer of configurable number of partitions

### DIFF
--- a/evolver/history/standard.py
+++ b/evolver/history/standard.py
@@ -55,8 +55,10 @@ class HistoryServer(History):
                 f"SELECT * FROM {self.json_hist_reader} WHERE time_part>=?",  # nosec: B608
                 params=(start_part,),
             )
-        except duckdb.IOException:
-            return
+        except duckdb.IOException as exc:
+            if "No files found" in str(exc):
+                return
+            raise
         self.db.execute("""INSERT INTO history (time_part, timestamp, name, data)
                         SELECT time_part, timestamp, name, data FROM to_backfill""")
 

--- a/evolver/history/standard.py
+++ b/evolver/history/standard.py
@@ -114,12 +114,13 @@ class HistoryServer(History):
         if t_start is None:
             t_start = (t_stop or time.time()) - self.default_window
 
+        buffer_start_part = self._get_part(time.time() - self.partition_seconds * self.buffer_partitions)
+        if t_start < buffer_start_part or self.buffer_partitions <= 0:
+            query = f"SELECT * FROM {self.json_hist_reader}"  # nosec: B608
+        else:
+            query = "SELECT * FROM history"
+
         try:
-            buffer_start_part = self._get_part(time.time() - self.partition_seconds * self.buffer_partitions)
-            if t_start < buffer_start_part or self.buffer_partitions <= 0:
-                query = f"SELECT * FROM {self.json_hist_reader}"  # nosec: B608
-            else:
-                query = "SELECT * FROM history"
             res = self._db.query(query)
         except duckdb.IOException as exc:
             if "No files found" in str(exc):

--- a/evolver/history/tests/test_history.py
+++ b/evolver/history/tests/test_history.py
@@ -13,9 +13,11 @@ def patch_storage(monkeypatch, tmp_path):
     monkeypatch.setattr(settings, "EXPERIMENT_FILE_STORAGE_PATH", tmp_path)
 
 
-@pytest.fixture(params=[(1, None), (1, "test"), (2, "test2")])
+@pytest.fixture(params=[(1, None, 3), (1, "test", 1), (2, "test2", 0)])
 def history_server(request):
-    return HistoryServer(partition_seconds=request.param[0], experiment=request.param[1])
+    return HistoryServer(
+        partition_seconds=request.param[0], experiment=request.param[1], buffer_partitions=request.param[2]
+    )
 
 
 @pytest.fixture


### PR DESCRIPTION
This is second of set of changes to make history perform better. For recent data (which should be most common to query) we additionaly store in-memory and query that if possible. Data are always also written out to disk and queryable when not satisfied in memory buffer.

brings UI latency from a couple seconds down to 10s of milliseconds for default query.

Resolves #183 