### PR TITLE
enable setting hardware inputs from web api

### DIFF
--- a/evolver/app/exceptions.py
+++ b/evolver/app/exceptions.py
@@ -9,3 +9,9 @@ class HardwareNotFoundError(HTTPException):
 class CalibratorNotFoundError(HTTPException):
     def __init__(self, **kwargs):
         return super().__init__(status_code=404, detail="Hardware has no calibrator", **kwargs)
+
+
+class OperationNotSupportedError(HTTPException):
+    def __init__(self, exception, **kwargs):
+        detail = f"Operation not supported: {exception}"
+        return super().__init__(status_code=400, detail=detail, **kwargs)

--- a/evolver/app/exceptions.py
+++ b/evolver/app/exceptions.py
@@ -1,17 +1,19 @@
+from http import HTTPStatus
+
 from fastapi import HTTPException
 
 
 class HardwareNotFoundError(HTTPException):
     def __init__(self, **kwargs):
-        return super().__init__(status_code=404, detail="Hardware not found", **kwargs)
+        return super().__init__(status_code=HTTPStatus.NOT_FOUND, detail="Hardware not found", **kwargs)
 
 
 class CalibratorNotFoundError(HTTPException):
     def __init__(self, **kwargs):
-        return super().__init__(status_code=404, detail="Hardware has no calibrator", **kwargs)
+        return super().__init__(status_code=HTTPStatus.NOT_FOUND, detail="Hardware has no calibrator", **kwargs)
 
 
 class OperationNotSupportedError(HTTPException):
     def __init__(self, exception, **kwargs):
         detail = f"Operation not supported: {exception}"
-        return super().__init__(status_code=400, detail=detail, **kwargs)
+        return super().__init__(status_code=HTTPStatus.BAD_REQUEST, detail=detail, **kwargs)

--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -1,5 +1,6 @@
 import asyncio
 from contextlib import asynccontextmanager
+from http import HTTPStatus
 
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
@@ -54,7 +55,7 @@ async def attribute_error_handler(_, exc):
 
 @app.exception_handler(ValidationError)
 async def validation_error_handler(_, exc):
-    return JSONResponse(status_code=422, content=exc.errors())
+    return JSONResponse(status_code=HTTPStatus.UNPROCESSABLE_ENTITY, content=exc.errors())
 
 
 app.include_router(hardware.router)

--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -2,10 +2,12 @@ import asyncio
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+from pydantic import ValidationError
 
 import evolver.util
 from evolver import __project__, __version__
-from evolver.app.exceptions import CalibratorNotFoundError, HardwareNotFoundError
+from evolver.app.exceptions import CalibratorNotFoundError, HardwareNotFoundError, OperationNotSupportedError
 from evolver.app.html_routes import html_app
 from evolver.app.models import SchemaResponse
 from evolver.base import require_all_fields
@@ -43,6 +45,16 @@ app.state.evolver = None
 
 @require_all_fields
 class EvolverConfigWithoutDefaults(Evolver.Config): ...
+
+
+@app.exception_handler(AttributeError)
+async def attribute_error_handler(_, exc):
+    raise OperationNotSupportedError(exc)
+
+
+@app.exception_handler(ValidationError)
+async def validation_error_handler(_, exc):
+    return JSONResponse(status_code=422, content=exc.errors())
 
 
 app.include_router(hardware.router)

--- a/evolver/app/routers/hardware.py
+++ b/evolver/app/routers/hardware.py
@@ -44,6 +44,27 @@ def get_hardware(hardware_name: str, request: Request):
     return hardware_instance.get()
 
 
+@router.post("/{hardware_name}/set")
+def hardware_set(hardware_name: str, request: Request, data: dict | list[dict], commit: bool = False):
+    hardware_instance = get_hardware_instance(request, hardware_name)
+    input_model = hardware_instance.Input
+    if isinstance(data, list):
+        inputs = [input_model.model_validate(i) for i in data]
+    else:
+        inputs = [input_model.model_validate(data)]
+
+    for input in inputs:
+        hardware_instance.set(input)
+    if commit:
+        hardware_instance.commit()
+
+
+@router.post("/{hardware_name}/commit")
+def hardware_commit(hardware_name: str, request: Request):
+    hardware_instance = get_hardware_instance(request, hardware_name)
+    hardware_instance.commit()
+
+
 # Start the calibration procedure for the selected hardware and vials
 @router.post("/{hardware_name}/calibrator/start")
 def start_calibration_procedure(

--- a/evolver/app/tests/test_hardware.py
+++ b/evolver/app/tests/test_hardware.py
@@ -1,9 +1,11 @@
+import json
+
 from fastapi.testclient import TestClient
 
 from evolver.app.main import app
 from evolver.calibration.demo import NoOpCalibrator
 from evolver.device import Evolver
-from evolver.hardware.demo import NoOpSensorDriver
+from evolver.hardware.demo import NoOpEffectorDriver, NoOpSensorDriver
 from evolver.tests.conftest import tmp_calibration_dir  # noqa: F401
 
 
@@ -59,3 +61,52 @@ class TestHardware:
             assert vial_data["raw"] == 1, f"Expected raw value 1, but got {vial_data['raw']}"
             assert vial_data["value"] == 2, f"Expected value 2, but got {vial_data['value']}"
             assert vial_data["vial"] == int(vial_id), f"Expected vial {vial_id}, but got {vial_data['vial']}"
+
+    def test_hardware_set(self):
+        app.state.evolver = Evolver(
+            hardware={
+                "effector": NoOpEffectorDriver(),
+                "sensor": NoOpSensorDriver(),
+            }
+        )
+        client = TestClient(app)
+        response = client.post("/hardware/effector/set", json={"vial": 0, "data": 30})
+        assert response.status_code == 200
+        proposals = [{"vial": 0, "data": 30}, {"vial": 1, "data": 40}]
+        response = client.post("/hardware/effector/set", json=proposals)
+        assert response.status_code == 200
+        response = client.post("/hardware/effector/set?commit=true", json=proposals)
+        assert response.status_code == 200
+        assert app.state.evolver.hardware["effector"].committed == {
+            p["vial"]: NoOpEffectorDriver.Input.model_validate(p) for p in proposals
+        }
+
+        response = client.post("/hardware/effector/set", json={"missing_vial": 0})
+        assert response.status_code == 422
+        try:
+            NoOpEffectorDriver.Input.model_validate({"missing_vial": 0})
+        except Exception as exc:
+            # The ValidationError data is not 1-to-1 with deserialized JSON due
+            # to containing tuples, so load from json, iso exc.errors()
+            exception_ = json.loads(exc.json())
+        assert exception_ == response.json()
+
+        response = client.post("/hardware/sensor/set", json={"vial": 0, "data": 30})
+        assert response.status_code == 400
+
+    def test_hardware_commit(self):
+        app.state.evolver = Evolver(
+            hardware={
+                "effector": NoOpEffectorDriver(),
+                "sensor": NoOpSensorDriver(),
+            }
+        )
+        client = TestClient(app)
+        expected = {0: NoOpEffectorDriver.Input(vial=0, data=30)}
+        app.state.evolver.hardware["effector"].set(expected[0])
+        response = client.post("/hardware/effector/commit")
+        assert response.status_code == 200
+        assert app.state.evolver.hardware["effector"].committed == expected
+
+        response = client.post("/hardware/sensor/commit")
+        assert response.status_code == 400

--- a/evolver/hardware/demo.py
+++ b/evolver/hardware/demo.py
@@ -32,4 +32,4 @@ class NoOpSensorDriver(SensorDriver):
 
 class NoOpEffectorDriver(EffectorDriver):
     def commit(self):
-        self.comitted = copy(self.proposal)
+        self.committed = copy(self.proposal)

--- a/evolver/hardware/standard/temperature.py
+++ b/evolver/hardware/standard/temperature.py
@@ -35,7 +35,7 @@ class Temperature(SensorDriver, EffectorDriver):
         temperature: float = Field(None, description="Sensor temperature in degrees Celsius")
 
     class Input(EffectorDriver.Input):
-        temperature: float = Field(None, description="Target temperature in degrees Celsius")
+        temperature: float = Field(description="Target temperature in degrees Celsius")
 
     @property
     def serial(self):


### PR DESCRIPTION
This change adds endpoints to set hardware inputs from the web api. Adds also some exception handling related to these changes. Along with a smuggled fix for temp inputs.

resolves #181 

**Note**: This allows one to set a value even when the controllers are enabled and might just overwrite it (not guaranteed to be overwritten, just possible). I *think* this is OK here, and any warning should probably be implemented at client level (UI or CLI client), where user interaction is managed. 

