### PR TITLE
Add abort api

### DIFF
--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -141,6 +141,14 @@ async def calibrate(name: str, data: dict = None):
     return calibrator.run_calibration_procedure(data)  # TODO: or **data?
 
 
+@app.post("/abort")
+async def abort():
+    app.state.evolver.abort()
+    # Disable commit also in persistent config in case application needs to restart
+    app.state.evolver.config_model.enable_commit = False
+    app.state.evolver.config_model.save(app_settings.CONFIG_FILE)
+
+
 app.mount("/html", html_app)
 
 

--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -145,8 +145,9 @@ async def calibrate(name: str, data: dict = None):
 async def abort():
     app.state.evolver.abort()
     # Disable commit also in persistent config in case application needs to restart
-    app.state.evolver.config_model.enable_commit = False
-    app.state.evolver.config_model.save(app_settings.CONFIG_FILE)
+    config = Evolver.Config.load(app_settings.CONFIG_FILE)
+    config.enable_commit = False
+    config.save(app_settings.CONFIG_FILE)
 
 
 app.mount("/html", html_app)

--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -146,6 +146,7 @@ async def abort():
     app.state.evolver.abort()
     # Disable commit also in persistent config in case application needs to restart
     config = Evolver.Config.load(app_settings.CONFIG_FILE)
+    config.enable_control = False
     config.enable_commit = False
     config.save(app_settings.CONFIG_FILE)
 

--- a/evolver/app/tests/test_app.py
+++ b/evolver/app/tests/test_app.py
@@ -207,6 +207,14 @@ class TestApp:
         else:
             assert response.json() == {"data": {}}
 
+    def test_abort_endpoint(self, app_client):
+        assert app.state.evolver.enable_commit
+        response = app_client.post("/abort")
+        assert response.status_code == 200
+        assert not app.state.evolver.enable_commit
+        saved_config = Evolver.Config.load(app_settings.CONFIG_FILE)
+        assert not saved_config.enable_commit
+
 
 def test_app_load_file(app_client):
     config = Evolver.Config(

--- a/evolver/device.py
+++ b/evolver/device.py
@@ -93,6 +93,11 @@ class Evolver(BaseInterface):
         if self.enable_commit:
             self.commit_proposals()
 
+    def abort(self):
+        self.enable_commit = False
+        for device in self.effectors.values():
+            device.abort()
+
     def __enter__(self):
         return self
 

--- a/evolver/device.py
+++ b/evolver/device.py
@@ -97,7 +97,7 @@ class Evolver(BaseInterface):
         self.enable_control = False
         self.enable_commit = False
         for device in self.effectors.values():
-            device.abort()
+            device.off()
 
     def __enter__(self):
         return self

--- a/evolver/device.py
+++ b/evolver/device.py
@@ -94,6 +94,7 @@ class Evolver(BaseInterface):
             self.commit_proposals()
 
     def abort(self):
+        self.enable_control = False
         self.enable_commit = False
         for device in self.effectors.values():
             device.abort()

--- a/evolver/hardware/demo.py
+++ b/evolver/hardware/demo.py
@@ -31,5 +31,12 @@ class NoOpSensorDriver(SensorDriver):
 
 
 class NoOpEffectorDriver(EffectorDriver):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.aborted = False
+
     def commit(self):
         self.committed = copy(self.proposal)
+
+    def off(self):
+        pass

--- a/evolver/hardware/demo.py
+++ b/evolver/hardware/demo.py
@@ -33,7 +33,6 @@ class NoOpSensorDriver(SensorDriver):
 class NoOpEffectorDriver(EffectorDriver):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.aborted = False
 
     def commit(self):
         self.committed = copy(self.proposal)

--- a/evolver/hardware/interface.py
+++ b/evolver/hardware/interface.py
@@ -83,5 +83,11 @@ class EffectorDriver(VialHardwareDriver):
         pass
 
     @abstractmethod
-    def abort(self):
+    def off(self):
+        """Immediately turn device into off state.
+
+        Used by framework in aborting an experiment. Implementations should
+        define off condition and implement in such a way that a commit call is
+        not necessary (i.e. the device turns off upon calling this method).
+        """
         pass

--- a/evolver/hardware/interface.py
+++ b/evolver/hardware/interface.py
@@ -81,3 +81,7 @@ class EffectorDriver(VialHardwareDriver):
     @abstractmethod
     def commit(self):
         pass
+
+    @abstractmethod
+    def abort(self):
+        pass

--- a/evolver/hardware/standard/led.py
+++ b/evolver/hardware/standard/led.py
@@ -35,7 +35,7 @@ class LED(EffectorDriver):
             comm.communicate(SerialData(addr=self.addr, data=cmd))
         self.committed = inputs
 
-    def abort(self):
+    def off(self):
         cmd = [b"0"] * self.slots
         with self.serial as comm:
             comm.communicate(SerialData(addr=self.addr, data=cmd))

--- a/evolver/hardware/standard/led.py
+++ b/evolver/hardware/standard/led.py
@@ -34,3 +34,8 @@ class LED(EffectorDriver):
         with self.serial as comm:
             comm.communicate(SerialData(addr=self.addr, data=cmd))
         self.committed = inputs
+
+    def abort(self):
+        cmd = [b"0"] * self.slots
+        with self.serial as comm:
+            comm.communicate(SerialData(addr=self.addr, data=cmd))

--- a/evolver/hardware/standard/pump.py
+++ b/evolver/hardware/standard/pump.py
@@ -95,7 +95,7 @@ class GenericPump(EffectorDriver):
             comm.communicate(SerialData(addr=self.addr, data=cmd))
         self.committed = inputs
 
-    def abort(self):
+    def off(self):
         cmd = [b"0"] * self.slots
         for pump in self.ipp_pumps:
             for solenoid in range(3):
@@ -164,5 +164,5 @@ class VialIEPump(EffectorDriver):
         self._generic_pump.commit()
         self.committed = copy(self.proposal)
 
-    def abort(self):
-        self._generic_pump.abort()
+    def off(self):
+        self._generic_pump.off()

--- a/evolver/hardware/standard/pump.py
+++ b/evolver/hardware/standard/pump.py
@@ -95,6 +95,14 @@ class GenericPump(EffectorDriver):
             comm.communicate(SerialData(addr=self.addr, data=cmd))
         self.committed = inputs
 
+    def abort(self):
+        cmd = [b"0"] * self.slots
+        for pump in self.ipp_pumps:
+            for solenoid in range(3):
+                cmd[pump * 3 + solenoid] = f"0|{pump}|{solenoid+1}".encode()
+        with self.serial as comm:
+            comm.communicate(SerialData(addr=self.addr, data=cmd))
+
 
 class VialIEPumpCalibrator(GenericPumpCalibrator):
     def run_calibration_procedure(self, *args, **kwargs):
@@ -155,3 +163,6 @@ class VialIEPump(EffectorDriver):
                 )
         self._generic_pump.commit()
         self.committed = copy(self.proposal)
+
+    def abort(self):
+        self._generic_pump.abort()

--- a/evolver/hardware/standard/stir.py
+++ b/evolver/hardware/standard/stir.py
@@ -34,3 +34,8 @@ class Stir(EffectorDriver):
         with self.serial as comm:
             comm.communicate(SerialData(addr=self.addr, data=cmd))
         self.committed = inputs
+
+    def abort(self):
+        cmd = [b"0"] * self.slots
+        with self.serial as comm:
+            comm.communicate(SerialData(addr=self.addr, data=cmd))

--- a/evolver/hardware/standard/stir.py
+++ b/evolver/hardware/standard/stir.py
@@ -35,7 +35,7 @@ class Stir(EffectorDriver):
             comm.communicate(SerialData(addr=self.addr, data=cmd))
         self.committed = inputs
 
-    def abort(self):
+    def off(self):
         cmd = [b"0"] * self.slots
         with self.serial as comm:
             comm.communicate(SerialData(addr=self.addr, data=cmd))

--- a/evolver/hardware/standard/temperature.py
+++ b/evolver/hardware/standard/temperature.py
@@ -70,3 +70,8 @@ class Temperature(SensorDriver, EffectorDriver):
 
     def commit(self):
         self._do_serial(from_proposal=True)
+
+    def abort(self):
+        cmd = [self.HEAT_OFF] * self.slots
+        with self.serial as comm:
+            comm.communicate(SerialData(addr=self.addr, data=cmd))

--- a/evolver/hardware/standard/temperature.py
+++ b/evolver/hardware/standard/temperature.py
@@ -71,7 +71,7 @@ class Temperature(SensorDriver, EffectorDriver):
     def commit(self):
         self._do_serial(from_proposal=True)
 
-    def abort(self):
+    def off(self):
         cmd = [self.HEAT_OFF] * self.slots
         with self.serial as comm:
             comm.communicate(SerialData(addr=self.addr, data=cmd))

--- a/evolver/hardware/standard/tests/test_standard.py
+++ b/evolver/hardware/standard/tests/test_standard.py
@@ -158,4 +158,4 @@ class TestStir(SerialVialEffectorHardwareTestSuite):
 )
 class TestPump(SerialVialEffectorHardwareTestSuite):
     driver = VialIEPump
-    abort_command = ({"addr": "pump", "slots": 2}, b"pumpr,0,0,0,0,0,0,_!")
+    abort_command = ({"addr": "pump", "slots": 2, "ipp_pumps": [1]}, b"pumpr,0,0,0,0|1|1,0|1|2,0|1|3,_!")

--- a/evolver/hardware/standard/tests/test_standard.py
+++ b/evolver/hardware/standard/tests/test_standard.py
@@ -83,6 +83,7 @@ class TestTempSensor:
 )
 class TestTempEffectorMode(SerialVialEffectorHardwareTestSuite):
     driver = Temperature
+    abort_command = ({"addr": "temp", "slots": 2}, b"tempr,4095,4095,_!")
 
 
 @pytest.mark.parametrize(
@@ -107,6 +108,7 @@ class TestTempEffectorMode(SerialVialEffectorHardwareTestSuite):
 )
 class TestLED(SerialVialEffectorHardwareTestSuite):
     driver = LED
+    abort_command = ({"addr": "od_led", "slots": 2}, b"od_ledr,0,0,_!")
 
 
 @pytest.mark.parametrize(
@@ -126,6 +128,7 @@ class TestLED(SerialVialEffectorHardwareTestSuite):
 )
 class TestStir(SerialVialEffectorHardwareTestSuite):
     driver = Stir
+    abort_command = ({"addr": "stir", "slots": 2}, b"stirr,0,0,_!")
 
 
 @pytest.mark.parametrize(
@@ -155,3 +158,4 @@ class TestStir(SerialVialEffectorHardwareTestSuite):
 )
 class TestPump(SerialVialEffectorHardwareTestSuite):
     driver = VialIEPump
+    abort_command = ({"addr": "pump", "slots": 2}, b"pumpr,0,0,0,0,0,0,_!")

--- a/evolver/hardware/test_utils.py
+++ b/evolver/hardware/test_utils.py
@@ -96,6 +96,7 @@ class SerialVialEffectorHardwareTestSuite:
     """
 
     driver: HardwareDriver = None
+    abort_command = None
 
     def _load_and_check(self, hw, values, serial_out):
         expected_committed = {}
@@ -118,3 +119,11 @@ class SerialVialEffectorHardwareTestSuite:
     def test_from_evolver_config(self, config_params, values, serial_out):
         evolver = _from_evolver_conf(self.driver, config_params, {})
         self._load_and_check(evolver.hardware["testhw"], values, serial_out)
+
+    def test_abort(self, config_params, values, serial_out):
+        if self.abort_command == "none_expected":
+            return
+        config, command = self.abort_command
+        hw = _from_config_desc(self.driver, config, {})
+        hw.abort()
+        assert hw.evolver.serial.backend.hits_map[command] == 1

--- a/evolver/hardware/test_utils.py
+++ b/evolver/hardware/test_utils.py
@@ -125,5 +125,5 @@ class SerialVialEffectorHardwareTestSuite:
             return
         config, command = self.abort_command
         hw = _from_config_desc(self.driver, config, {})
-        hw.abort()
+        hw.off()
         assert hw.evolver.serial.backend.hits_map[command] == 1

--- a/evolver/tests/test_device.py
+++ b/evolver/tests/test_device.py
@@ -144,3 +144,10 @@ class TestEvolver:
         assert isinstance(status["testsensor"].input_transformer, Status)
         assert isinstance(status["testsensor"].output_transformer, Status)
         assert status["testsensor"].ok
+
+    def test_abort(self, demo_evolver):
+        assert not demo_evolver.hardware["testeffector"].aborted
+        demo_evolver.enable_commit = True
+        demo_evolver.abort()
+        assert not demo_evolver.enable_commit
+        assert demo_evolver.hardware["testeffector"].aborted

--- a/evolver/tests/test_device.py
+++ b/evolver/tests/test_device.py
@@ -7,7 +7,7 @@ from evolver.calibration.interface import Calibrator, Status
 from evolver.connection.interface import Connection
 from evolver.controller.interface import Controller
 from evolver.device import DEFAULT_HISTORY, DEFAULT_SERIAL, Evolver
-from evolver.hardware.demo import NoOpSensorDriver
+from evolver.hardware.demo import NoOpEffectorDriver, NoOpSensorDriver
 from evolver.hardware.interface import HardwareDriver
 from evolver.history.interface import History
 
@@ -145,9 +145,15 @@ class TestEvolver:
         assert isinstance(status["testsensor"].output_transformer, Status)
         assert status["testsensor"].ok
 
-    def test_abort(self, demo_evolver):
-        assert not demo_evolver.hardware["testeffector"].aborted
+    def test_abort(self, demo_evolver, monkeypatch):
+        test_effector = demo_evolver.hardware["testeffector"]
+        test_effector.aborted = False
+
+        def patched_abort(self):
+            self.aborted = True
+
+        monkeypatch.setattr(NoOpEffectorDriver, "abort", patched_abort)
         demo_evolver.enable_commit = True
         demo_evolver.abort()
         assert not demo_evolver.enable_commit
-        assert demo_evolver.hardware["testeffector"].aborted
+        assert test_effector.aborted

--- a/evolver/tests/test_device.py
+++ b/evolver/tests/test_device.py
@@ -151,8 +151,8 @@ class TestEvolver:
                 super().__init__(*args, **kwargs)
                 self.aborted = False
 
-            def abort(self):
-                super().abort()
+            def off(self):
+                super().off()
                 self.aborted = True
 
         demo_evolver.hardware["testeffector"] = AbortEffector()

--- a/evolver/tests/test_device.py
+++ b/evolver/tests/test_device.py
@@ -145,15 +145,18 @@ class TestEvolver:
         assert isinstance(status["testsensor"].output_transformer, Status)
         assert status["testsensor"].ok
 
-    def test_abort(self, demo_evolver, monkeypatch):
-        test_effector = demo_evolver.hardware["testeffector"]
-        test_effector.aborted = False
+    def test_abort(self, demo_evolver):
+        class AbortEffector(NoOpEffectorDriver):
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.aborted = False
 
-        def patched_abort(self):
-            self.aborted = True
+            def abort(self):
+                super().abort()
+                self.aborted = True
 
-        monkeypatch.setattr(NoOpEffectorDriver, "abort", patched_abort)
+        demo_evolver.hardware["testeffector"] = AbortEffector()
         demo_evolver.enable_commit = True
         demo_evolver.abort()
         assert not demo_evolver.enable_commit
-        assert test_effector.aborted
+        assert demo_evolver.hardware["testeffector"].aborted


### PR DESCRIPTION
Sets up API for abort, which would put all devices into a stopped state (whatever that means for a particular device still in the powered-on state). The device-level action both stops the control components of loop and also the all devices, while the web-app (application-level) aborts the device and writes out the control disablement to config, such that a restart would not inadvertently continue normal operation without user intervention (given the current mainline behavior of the system)

Resolves #121 