### PR TITLE
Iainland/refactor history endpoint - split GET and POST handlers

### DIFF
--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -89,7 +89,6 @@ async def get_schema(classinfo: ImportString | None = evolver.util.fully_qualifi
     return SchemaResponse(classinfo=classinfo)
 
 
-@app.get("/history/", operation_id="history")
 @app.post("/history/", operation_id="history")
 async def get_history(
     name: str = None,


### PR DESCRIPTION
HTTP standards demand GET requests do not include a body, all GET params must be passed as query elements.
