### PR TITLE
make config file, working dir agnostic, enables debugging of evolver.app.main module in pycharm

### DIFF
--- a/evolver/settings.py
+++ b/evolver/settings.py
@@ -34,7 +34,9 @@ class Settings(BaseSettings):
 
 
 class AppSettings(BaseSettings):
-    CONFIG_FILE: Path = Path("evolver.yml")  # in current directory
+    CONFIG_FILE: Path = (
+        Path(__file__).resolve().parent.parent / "evolver.yml"
+    )  # CONFIG_FILE is in the project root, regardless of the working directory.
     LOAD_FROM_CONFIG_ON_STARTUP: bool = True
     HOST: str = "127.0.0.1"
     PORT: int = 8080

--- a/evolver/settings.py
+++ b/evolver/settings.py
@@ -34,12 +34,26 @@ class Settings(BaseSettings):
 
 
 class AppSettings(BaseSettings):
-    CONFIG_FILE: Path = (
-        Path(__file__).resolve().parent.parent / "evolver.yml"
-    )  # CONFIG_FILE is in the project root, regardless of the working directory.
+    def find_project_root(self, marker: str = "pyproject.toml") -> Path:
+        """
+        Find the project root by looking for a marker file in parent directories.
+        Defaults to "pyproject.toml".
+        """
+        path = Path(__file__).resolve()
+        for parent in path.parents:
+            if (parent / marker).exists():
+                return parent
+        raise FileNotFoundError(f"Project root marker '{marker}' not found in any parent directories.")
+
+    CONFIG_FILE: Path | None = None
     LOAD_FROM_CONFIG_ON_STARTUP: bool = True
     HOST: str = "127.0.0.1"
     PORT: int = 8080
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self.CONFIG_FILE is None:
+            self.CONFIG_FILE = self.find_project_root() / "evolver.yml"
 
 
 settings = Settings()


### PR DESCRIPTION
Working Pycharm debug on `evolver.app.main` module. Useful for (frontend) development against the http api.

Screenshot of working config.

<img width="2552" alt="Screenshot 2024-11-18 at 3 21 50 PM" src="https://github.com/user-attachments/assets/adfb7e55-be77-40d9-a3b2-8642d8d3c579">
