### PR TITLE
extend calibration procedure actions response

### DIFF
--- a/evolver/app/routers/hardware.py
+++ b/evolver/app/routers/hardware.py
@@ -98,7 +98,7 @@ def get_calibrator_actions(hardware_name: str, request: Request):
         {
             "name": action.name,
             "description": action.description,
-            "requires_input": action.requires_input,
+            "requires_input": action.FormModel.model_fields != {},
             "input_schema": action.FormModel.schema() if action.FormModel else None,
         }
         for action in calibration_procedure.get_actions()

--- a/evolver/app/routers/hardware.py
+++ b/evolver/app/routers/hardware.py
@@ -98,7 +98,6 @@ def get_calibrator_actions(hardware_name: str, request: Request):
         {
             "name": action.name,
             "description": action.description,
-            "requires_input": action.FormModel.model_fields != {},
             "input_schema": action.FormModel.schema() if action.FormModel else None,
         }
         for action in calibration_procedure.get_actions()

--- a/evolver/app/routers/hardware.py
+++ b/evolver/app/routers/hardware.py
@@ -93,8 +93,15 @@ def get_calibrator_actions(hardware_name: str, request: Request):
     if not calibrator:
         raise CalibratorNotFoundError
     calibration_procedure = calibrator.calibration_procedure
+
     actions = [
-        {"name": action.name, "description": action.description} for action in calibration_procedure.get_actions()
+        {
+            "name": action.name,
+            "description": action.description,
+            "requires_input": action.requires_input,
+            "input_schema": action.FormModel.schema() if action.FormModel else None,
+        }
+        for action in calibration_procedure.get_actions()
     ]
     return {"actions": actions}
 

--- a/evolver/app/tests/test_calibration.py
+++ b/evolver/app/tests/test_calibration.py
@@ -67,7 +67,6 @@ def test_temperature_calibration_procedure_actions():
         {
             "name": action.name,
             "description": action.description,
-            "requires_input": action.FormModel.model_fields != {},
             "input_schema": action.FormModel.schema() if action.FormModel else None,
         }
         for action in temp_calibrator.calibration_procedure.actions

--- a/evolver/app/tests/test_calibration.py
+++ b/evolver/app/tests/test_calibration.py
@@ -64,7 +64,12 @@ def test_temperature_calibration_procedure_actions():
     actions_response = client.get("hardware/test/calibrator/procedure/actions")
     assert actions_response.status_code == 200
     expected_actions = [
-        {"name": action.name, "description": action.description}
+        {
+            "name": action.name,
+            "description": action.description,
+            "requires_input": action.requires_input,
+            "input_schema": action.FormModel.schema() if action.FormModel else None,
+        }
         for action in temp_calibrator.calibration_procedure.actions
     ]
 

--- a/evolver/app/tests/test_calibration.py
+++ b/evolver/app/tests/test_calibration.py
@@ -67,7 +67,7 @@ def test_temperature_calibration_procedure_actions():
         {
             "name": action.name,
             "description": action.description,
-            "requires_input": action.requires_input,
+            "requires_input": action.FormModel.model_fields != {},
             "input_schema": action.FormModel.schema() if action.FormModel else None,
         }
         for action in temp_calibrator.calibration_procedure.actions

--- a/evolver/calibration/action.py
+++ b/evolver/calibration/action.py
@@ -15,14 +15,18 @@ class CalibrationAction(ABC):
                 Must be unique within a procedure.
             description (str): A short description of the action's purpose.
                 Useful for documentation or display of instructions to the person performing a calibration procedure action.
-            requires_input (bool): Indicates whether this action requires user input.
-                Actions that require input should have a FormModel defined to express the model of the required user input.
         """
         self.name = name
         self.description = description
-        self.requires_input = requires_input
 
     class FormModel(BaseModel):
+        """
+        A Pydantic model for the input to the action.
+        For actions that require input, this should be overridden in a subclass.
+        This is used by the frontend to generate a form for the user to fill out.
+        Actions that do not require input should leave this empty
+        """
+
         pass
 
     @abstractmethod

--- a/evolver/calibration/action.py
+++ b/evolver/calibration/action.py
@@ -5,7 +5,11 @@ from pydantic import BaseModel
 
 
 class CalibrationAction(ABC):
-    def __init__(self, name: str, description: str, requires_input: bool = False):
+    def __init__(
+        self,
+        name: str,
+        description: str,
+    ):
         """
         Initialize a CalibrationAction.
 

--- a/evolver/calibration/procedure.py
+++ b/evolver/calibration/procedure.py
@@ -46,7 +46,7 @@ class CalibrationProcedure(BaseInterface, ABC):
         return self.state
 
     def dispatch(self, action: CalibrationAction, payload: Dict[str, Any]):
-        if payload is not None and action.requires_input:
+        if payload is not None and action.FormModel.model_fields != {}:
             payload = action.FormModel(**payload)
         self.state = action.execute(self.state, payload)
         return self.state

--- a/evolver/calibration/standard/actions/temperature.py
+++ b/evolver/calibration/standard/actions/temperature.py
@@ -7,10 +7,15 @@ from evolver.calibration.action import CalibrationAction
 
 class ReferenceValueAction(CalibrationAction):
     class FormModel(BaseModel):
+        """
+        Because this action requires manual user input, we define a Pydantic model for the input to the action.
+        This is used by the frontend to generate a form for the user to fill out.
+        """
+
         temperature: float = Field(..., title="Temperature", description="Temperature in degrees Celsius")
 
     def __init__(self, hardware, vial_idx: int, *args, **kwargs):
-        super().__init__(requires_input=True, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.hardware = hardware
         self.vial_idx = vial_idx
 


### PR DESCRIPTION
Adds the input schema to the get actions response. This allows the front end to present the required input UI for the action.