### PR TITLE
Add nested config test and temp downgrade of pydantic

### DIFF
--- a/evolver/tests/test_base.py
+++ b/evolver/tests/test_base.py
@@ -5,6 +5,9 @@ import pytest
 
 import evolver.base
 import evolver.util
+from evolver.calibration.standard.calibrators.temperature import TemperatureCalibrator
+from evolver.device import Evolver
+from evolver.hardware.standard.temperature import Temperature
 
 
 class ConcreteInterface(evolver.base.BaseInterface):
@@ -218,6 +221,22 @@ class TestBaseInterface:
         obj = ConcreteInterface.create(mock_config_file)
         assert obj.a == 44
         assert obj.b == 55
+
+    def test_nested_config_models(self):
+        # Setup.
+        calibrator = TemperatureCalibrator()
+        hardware = Temperature(addr="x", calibrator=calibrator)
+        config = Evolver(hardware={"test": hardware}).config
+
+        # Test hardware description.
+        hardware_descriptor = config["hardware"]["test"]
+        assert set(hardware_descriptor.keys()) == {"classinfo", "config"}
+        assert hardware_descriptor["classinfo"] == evolver.util.fully_qualified_name(hardware.__class__)
+
+        # Test calibrator description.
+        calibrator_descriptor = hardware_descriptor["config"]["calibrator"]
+        assert set(calibrator_descriptor.keys()) == {"classinfo", "config"}
+        assert calibrator_descriptor["classinfo"] == evolver.util.fully_qualified_name(calibrator.__class__)
 
 
 class TestConfigDescriptor:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "duckdb",
     "fastapi[all]",
     "numpy",
-    "pydantic",
+    "pydantic<2.8",
     "pydantic-settings",
     "pyserial",
     "scipy",

--- a/requirements/prd.txt
+++ b/requirements/prd.txt
@@ -1,7 +1,7 @@
 fastapi==0.115.4
 numpy==2.1.2
 duckdb==1.1.2
-pydantic==2.9.2
+pydantic==2.7.4
 pydantic-settings==2.6.0
 pyserial==3.5
 uvicorn[standard]==0.32.0


### PR DESCRIPTION
Relates to #213

This still needs further investigation to determine whether something will remain broken for newer versions of ``pydantic``.  This does not resolve #213, but will temporarily band-aid it.