### PR TITLE
Refactor evolver.base

### DIFF
--- a/evolver/base.py
+++ b/evolver/base.py
@@ -41,50 +41,14 @@ def require_all_fields(cls):
     return cls
 
 
-class _BaseConfig(pydantic.BaseModel):
+def _is_descriptor_dict(obj: Any) -> bool:
+    if isinstance(obj, dict) and (set(obj.keys()) == set(ConfigDescriptor.model_fields)):
+        return True
+    return False
+
+
+class _BaseModel(pydantic.BaseModel):
     model_config = pydantic.ConfigDict(extra="ignore", from_attributes=True)
-
-    @classmethod
-    def get_classinfo(cls):
-        """The fully qualified classname for cls's container class (if one exists).
-           Raises `TypeError` if parent class is not derived from BaseInterface.
-        """
-        fqn = evolver.util.fully_qualified_name(cls)
-        containers = fqn.split('.')[:-1]
-        container = ".".join(containers)
-        container_class = import_string(container)
-        if issubclass(container_class, BaseInterface):
-            cls = container_class
-        return f"{cls.__module__}.{cls.__qualname__}"
-
-    @pydantic.model_serializer(mode="wrap", when_used='json')
-    def to_descriptor(self, handler) -> dict:
-        serialized_by_super = handler(self)
-        if issubclass(self.__class__, ConfigDescriptor):
-            return serialized_by_super
-        return dict(classinfo=self.get_classinfo(), config=serialized_by_super)
-
-    @classmethod
-    def model_validate(cls, obj, *, strict=None, from_attributes=None, context=None):
-        """Effectively the same as pydantic.BaseModel.model_validate() except that it automatically handles json, and
-        conversion from instances of ``BaseConfig`` and ``BaseInterface`
-        """
-        if obj is None:
-            return cls()
-        elif isinstance(obj, os.PathLike):
-            return cls.load(file_path=obj)
-        elif isinstance(obj, (str, bytes, bytearray)):
-            return cls.model_validate_json(obj, strict=strict, context=context)
-        elif isinstance(obj, ConfigDescriptor):
-            return super().model_validate(obj.config, strict=strict, from_attributes=from_attributes, context=context)
-        elif isinstance(obj, BaseInterface):
-            return super().model_validate(
-                obj.config,  # Objects are responsible for their own conversion to config.
-                strict=strict,
-                from_attributes=from_attributes,
-                context=context,
-            )
-        return super().model_validate(obj, strict=strict, from_attributes=from_attributes, context=context)
 
     @classmethod
     def load(cls, file_path: Path, encoding: str | None = None):
@@ -114,6 +78,62 @@ class _BaseConfig(pydantic.BaseModel):
         return dict(self)
 
 
+class _BaseConfig(_BaseModel):
+
+    @classmethod
+    def get_classinfo(cls):
+        """The fully qualified classname for cls's container class (if one exists).
+           Raises `TypeError` if parent class is not derived from BaseInterface.
+        """
+        fqn = evolver.util.fully_qualified_name(cls)
+        containers = fqn.split('.')[:-1]
+        container = ".".join(containers)
+        container_class = import_string(container)
+        if issubclass(container_class, BaseInterface):
+            cls = container_class
+        return f"{cls.__module__}.{cls.__qualname__}"
+
+    # @pydantic.model_serializer(mode="wrap", when_used='json')
+    # def to_descriptor(self, handler) -> dict:
+    #     serialized_by_super = handler(self)
+    #     if isinstance(serialized_by_super, dict) and (set(serialized_by_super.keys()) == {"classinfo", "config"}):
+    #         return serialized_by_super
+    #     return dict(classinfo=self.get_classinfo(), config=serialized_by_super)
+
+    @classmethod
+    def model_validate(cls, obj, *, strict=None, from_attributes=None, context=None):
+        """Effectively the same as pydantic.BaseModel.model_validate() except that it automatically handles json, and
+        conversion from instances of ``ConfigDescriptor``, ``BaseConfig`` and ``BaseInterface`
+        """
+        if obj is None:
+            return cls()
+        elif isinstance(obj, os.PathLike):
+            return cls.load(file_path=obj)
+        elif isinstance(obj, (str, bytes, bytearray)):
+            try:
+                # json str might be that for a ConfigDescriptor, so try that 1st.
+                descriptor = ConfigDescriptor.model_validate_json(obj, strict=strict, context=context)
+            except Exception:
+                # Ok, maybe it wasn't a ConfigDescriptor...
+                return cls.model_validate_json(obj, strict=strict, context=context)
+            else:
+                # Cool, it was a ConfigDescriptor so validate from that.
+                return super().model_validate(descriptor.config, strict=strict, from_attributes=from_attributes, context=context)
+        elif isinstance(obj, ConfigDescriptor):
+            return super().model_validate(obj.config, strict=strict, from_attributes=from_attributes, context=context)
+        elif _is_descriptor_dict(obj):
+            descriptor = ConfigDescriptor.model_validate(obj)
+            return super().model_validate(descriptor.config, strict=strict, from_attributes=from_attributes, context=context)
+        elif isinstance(obj, BaseInterface):
+            return super().model_validate(
+                obj.config_model,  # Objects are responsible for their own conversion to config.
+                strict=strict,
+                from_attributes=from_attributes,
+                context=context,
+            )
+        return super().model_validate(obj, strict=strict, from_attributes=from_attributes, context=context)
+
+
 class TimeStamp(_BaseConfig):
     created: pydantic.PastDatetime | None = CreatedTimestampField()
     expire: datetime.timedelta | None = ExpireField()
@@ -123,9 +143,16 @@ class BaseConfig(_BaseConfig):
     name: str | None = None
 
 
-class ConfigDescriptor(_BaseConfig):
+class ConfigDescriptor(_BaseModel):
     classinfo: ImportString
     config: dict = {}
+
+    @pydantic.field_validator('classinfo', mode="after")
+    @classmethod
+    def validate_classinfo(cls, v):
+        if not issubclass(v, BaseInterface):
+            raise ValueError(f"classinfo must represent a subclass of '{BaseInterface.__qualname__}'")
+        return v
 
     @classmethod
     def model_validate(cls, obj, *args, **kwargs):
@@ -145,24 +172,34 @@ class ConfigDescriptor(_BaseConfig):
         #  serializable. The very point of the pydantic framework is to solve this issue.
 
         if isinstance(obj, type) and issubclass(obj, BaseInterface):
-            return super().model_validate(
-                dict(classinfo=evolver.util.fully_qualified_name(obj), config=obj.Config().model_dump(mode="json")),
-                *args,
-                **kwargs,
-            )
-        elif isinstance(obj, BaseConfig) and (classinfo := obj.__pydantic_parent_namespace__.get("__qualname__")):
-            return super().model_validate(
-                dict(classinfo=f"{obj.__module__}.{classinfo}", config=obj.model_dump(mode="json")), *args, **kwargs
-            )
+            # `obj` is a class not an instance, which means that it can't have a config other than the default,
+            # so we pass in obj.Config().
+            model = super().model_validate(dict(classinfo=evolver.util.fully_qualified_name(obj),
+                                                config=obj.Config().model_dump()))
+        elif isinstance(obj, BaseConfig):
+            model = super().model_validate(dict(classinfo=obj.get_classinfo(), config=obj.model_dump()))
         elif isinstance(obj, BaseInterface):
-            return super().model_validate(dict(classinfo=obj.classinfo, config=obj.config), *args, **kwargs)
-        return super().model_validate(obj, *args, **kwargs)
+            model = super().model_validate(dict(classinfo=obj.classinfo, config=obj.config))
+        elif isinstance(obj, (str, bytes, bytearray)):
+            model = super().model_validate_json(obj, *args, **kwargs)
+        elif isinstance(obj, os.PathLike):
+            return cls.load(file_path=obj)
+        else:
+            model = super().model_validate(obj, *args, **kwargs)
 
-    def create(self, update: Dict[str, Any] | None = None, non_config_kwargs: Dict[str, Any] | None = None, **kwargs):
+        # Validate config.
+        model.classinfo.Config.model_validate(model.config)
+
+        return model
+
+    def create(self,
+               update: Dict[str, Any] | None = None,
+               non_config_kwargs: Dict[str, Any] | None = None,
+               **kwargs):
         """Create an instance of classinfo from a config.
 
         Args:
-            update (:obj:`dict`): Key-value pairs used to override contents of ``self.config``. These get validated.
+            update (:obj:`dict`): Key-value pairs used to override contents of ``self.config``.
             non_config_kwargs (:obj:`dict`): Key-value pairs passed to ``classinfo`` upon instantiation. These are
                                              not validated.
             **kwargs: Synonymous with ``update``. Values here take precedence over any in update, i.e., ``config``
@@ -191,19 +228,6 @@ class ConfigDescriptor(_BaseConfig):
             if non_config_kwargs
             else self.classinfo(**config.shallow_model_dump())
         )
-
-    @classmethod
-    def load(cls, file_path: Path, encoding: str | None = None):
-        """Loads the specified config file and return a new instance."""
-        with open(file_path, encoding=encoding) as f:
-            return cls.model_validate(yaml.safe_load(f))
-
-    def save(self, file_path: Path, encoding: str | None = None):
-        """Write out config as yaml file to specified file."""
-        file_path = Path(file_path)
-        file_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(file_path, "w", encoding=encoding) as f:
-            yaml.dump(self.model_dump(mode="json"), f)
 
 
 class BaseInterface(ABC):
@@ -235,36 +259,53 @@ class BaseInterface(ABC):
 
     class Config(BaseConfig): ...
 
+    # @pydantic.model_serializer(mode="wrap", when_used='json')
+    # def to_descriptor(self, handler) -> dict:
+    #     serialized_by_super = handler(self)
+    #     if isinstance(serialized_by_super, dict) and (set(serialized_by_super.keys()) == {"classinfo", "config"}):
+    #         return serialized_by_super
+    #     return dict(classinfo=self.classinfo, config=serialized_by_super)
+
     @classmethod
-    def create(cls, config: ConfigDescriptor | dict | str | None = None):
+    def create(cls, config: ConfigDescriptor | BaseConfig | dict | str | None = None):
         """Create an instance from a config."""
 
-        def validate_descriptor(descriptor: ConfigDescriptor):
-            if not issubclass(cls, descriptor.classinfo):
+        def validate_classinfo(classinfo: type | str):
+            classinfo = import_string(classinfo) if isinstance(classinfo, str) else classinfo
+            if not issubclass(classinfo, cls):
                 raise TypeError(
-                    f"The given {ConfigDescriptor.__name__} for '{descriptor.classinfo}' is not compatible "
+                    f"The given {ConfigDescriptor.__name__} for '{classinfo}' is not compatible "
                     f"with this class '{cls.__qualname__}'"
                 )
-            return cls.Config.model_validate(descriptor, context=dict(extra="forbid"))
 
-        # We first try to create a valid Config instance and then from that create an instance of cls.
+        # We first create a validated Config instance and then use that to create an instance of cls.
         if config is None:
             # Empty config.
             config = cls.Config()
+        elif isinstance(config, _BaseConfig):
+            pass
         elif isinstance(config, ConfigDescriptor):
-            config = validate_descriptor(config)
+            validate_classinfo(config.classinfo)
+            config = config.config  # This has already been validated but is still just a dict.
+        elif _is_descriptor_dict(config):
+            validate_classinfo(config["classinfo"])
+            config = cls.Config.model_validate(config["config"])
+        elif isinstance(config, dict):
+            config = cls.Config.model_validate(config)
         else:
-            # Next handle dict | str, which could be that representing a Config or a ConfigDescriptor.
-            # First see if config is actually a descriptor by trying to create one, since it's only fields are limited
-            # to classinfo and config.
+            # Last is a str representing either a Config or ConfigDescriptor.
             try:
                 descriptor = ConfigDescriptor.model_validate(config, context=dict(extra="forbid"))
-                config = validate_descriptor(descriptor)
-            except pydantic.ValidationError:
+            except pydantic.ValidationError as error:
                 config = cls.Config.model_validate(config)
+            else:
+                validate_classinfo(descriptor.classinfo)
+                config = descriptor.config
+
+        config_dict = config.shallow_model_dump() if isinstance(config, _BaseConfig) else config
 
         # Instantiate cls from config.
-        return cls(**config.shallow_model_dump())
+        return cls(**config_dict)
 
     def __init__(self, *args, name: str = None, auto_config=True, auto_config_ignore_fields=None, **kwargs):
         self.name = name or self.__class__.__name__

--- a/evolver/base.py
+++ b/evolver/base.py
@@ -8,7 +8,6 @@ from typing import Any, Dict
 import pydantic
 import pydantic_core
 import yaml
-from pydantic._internal._validators import import_string
 
 import evolver.util
 from evolver.settings import settings
@@ -101,7 +100,7 @@ class _BaseConfig(_BaseModel):
         fqn = evolver.util.fully_qualified_name(cls)
         containers = fqn.split(".")[:-1]
         container = ".".join(containers)
-        container_class = import_string(container)
+        container_class = evolver.util.import_string(container)
         if issubclass(container_class, BaseInterface):
             cls = container_class
         return f"{cls.__module__}.{cls.__qualname__}"
@@ -269,7 +268,7 @@ class BaseInterface(ABC):
         """Create an instance from a config."""
 
         def validate_classinfo(classinfo: type | str):
-            classinfo = import_string(classinfo) if isinstance(classinfo, str) else classinfo
+            classinfo = evolver.util.import_string(classinfo) if isinstance(classinfo, str) else classinfo
             if not issubclass(classinfo, cls):  # TODO: don't allow polymorph?
                 raise TypeError(
                     f"The given {ConfigDescriptor.__name__} for '{classinfo}' is not compatible "

--- a/evolver/base.py
+++ b/evolver/base.py
@@ -299,7 +299,9 @@ class BaseInterface(ABC):
                 validate_classinfo(descriptor.classinfo)
                 config = descriptor.config
 
-        config_dict = config.shallow_model_dump() if isinstance(config, _BaseConfig) else config
+        # Some of the conversions above are already dictionaries, i.e., ``config = descriptor.config``, most aren't.
+        # Convert those that aren't so that they can be unpacked in the ``return`` statement below.
+        config_dict = config.shallow_model_dump() if isinstance(config, _BaseModel) else config
 
         # Instantiate cls from config.
         return cls(**config_dict)

--- a/evolver/tests/test_base.py
+++ b/evolver/tests/test_base.py
@@ -17,8 +17,7 @@ class ConcreteInterface(evolver.base.BaseInterface):
         b: int = 3
 
 
-class ConcreteInterface2(evolver.base.BaseInterface):
-    ...
+class ConcreteInterface2(evolver.base.BaseInterface): ...
 
 
 class Nested(evolver.base.BaseInterface):

--- a/evolver/tests/test_base.py
+++ b/evolver/tests/test_base.py
@@ -84,6 +84,9 @@ class TestBaseConfig:
         assert obj.a == 44
         assert obj.b == 55
 
+    def test_classinfo(self):
+        assert ConcreteInterface.Config.classinfo() == evolver.util.fully_qualified_name(ConcreteInterface)
+
 
 class TestBaseInterface:
     def test_create(self):

--- a/evolver/tests/test_base.py
+++ b/evolver/tests/test_base.py
@@ -72,9 +72,9 @@ class TestBaseConfig:
         assert obj.a == 6
         assert obj.b == 7
 
-    def test_from_config_descriptor(self, mock_descriptor):
-        assert isinstance(mock_descriptor, evolver.base.ConfigDescriptor)
-        obj = ConcreteInterface.Config.model_validate(mock_descriptor)
+    @pytest.mark.parametrize("descriptor", ("mock_descriptor", "mock_descriptor_as_json"))
+    def test_from_config_descriptor(self, descriptor, request):
+        obj = ConcreteInterface.Config.model_validate(request.getfixturevalue(descriptor))
         assert isinstance(obj, ConcreteInterface.Config)
         assert obj.a == 11
         assert obj.b == 22

--- a/evolver/util.py
+++ b/evolver/util.py
@@ -3,6 +3,8 @@ import logging
 import os
 from pathlib import Path
 
+import pydantic
+
 from evolver import __project__
 from evolver.settings import settings
 
@@ -26,3 +28,13 @@ def setup_logging(level=settings.LOG_LEVEL, format=settings.LOG_FORMAT):
 
 def filter_data_properties(data, properties=[]):
     return {k: v for k, v in data.items() if not properties or k in properties}
+
+
+def import_string(dotted_path: str) -> type:
+    """Import and convert a dotted path to its actual class type."""
+
+    # Utilize pydantic._internal._validators.import_string validation without illegally importing protected methods.
+    class Wrapper(pydantic.BaseModel):
+        import_string: pydantic.ImportString
+
+    return Wrapper.model_validate(dict(import_string=dotted_path)).import_string

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,5 +1,5 @@
 from evolver import __project__, __version__
-from evolver.util import find_package_location, find_repo_location
+from evolver.util import find_package_location, find_repo_location, import_string
 
 
 def test_find_repo_location():
@@ -29,3 +29,12 @@ def test_version():
 
 def test_project():
     assert __project__
+
+
+def test_import_string():
+    import_type = import_string("evolver.device.Evolver")
+    assert isinstance(import_type, type)
+
+    from evolver.device import Evolver
+
+    assert import_type is Evolver


### PR DESCRIPTION
#213 Was the main driver for this refactor. However, it does not fix that issue but instead refactors some code to make things more manageable to future changes.

The core change is the creation of ``_BaseModel`` for the separation of conversion back and forth between ``Config``, instances, and ``ConfigDescriptors`` such that it is clearer where in the code this happens - it is no longer circular. For clarity ``_BaseModel`` does not handle the conversion between ``Config`` and ``configDescriptor`` and instead only includes other base conversions, i.e., json strings. Soln. to #234 would also go in this new class. This PR introduces some duplication in logic, but at the expense of it being more direct and explicit per specific desired class behavior.

This should also help and relate to #234.