### PR TITLE
add link to api docs to the network endpoint

### DIFF
--- a/evolver/app/html_routes.py
+++ b/evolver/app/html_routes.py
@@ -22,6 +22,7 @@ async def network_html():
             <p>Running '{__project__}' ver: '{__version__}'</p>
             <p>Hostname: {hostname}</p>
             <p>IP Address: {ip_address}</p>
+            <a href="/docs">API Documentation</a>
         </body>
     </html>
     """


### PR DESCRIPTION
See screenshot, adds "api documentation" link:
<img width="528" alt="Screenshot 2024-12-09 at 1 43 27 PM" src="https://github.com/user-attachments/assets/daf1efbd-00c9-465e-b009-adcc5ac5c3ec">
