### PR TITLE
Log pass through user supplied extra data

### DIFF
--- a/evolver/logutils.py
+++ b/evolver/logutils.py
@@ -10,11 +10,15 @@ logging.addLevelName(EVENT, "EVENT")
 class LogInfo:
     """Helper class to provide "extra" to log records integrated with history.
 
-    This class acts similar to a dict, but with all fields within a dict under a
-    specific key and ensures the fields are json-serializable. Used with the
-    history integration, fields provided will be available in the stored record.
-    This is useful because all fields within extra are placed at the top level
-    of a logrecord dict, so otherwise there is no way to distinguish them.
+    This class acts similar to a dict, but with all fields within it "keyed" by
+    an EXTRA_KEY that is stripped when the log event is read. This has the
+    effect of normalizing LogInfo data, so that when it is read it appears at
+    the same level as the Log entry's top-level properties.
+
+    Note:
+        This is useful because all fields within extra are placed at the top
+        level of a logrecord dict, so otherwise there is no way to distinguish
+        them.
 
     Example:
         self.logger.log(EVENT, "Event message", extra=LogInfo(vial=1))

--- a/evolver/logutils.py
+++ b/evolver/logutils.py
@@ -8,6 +8,19 @@ logging.addLevelName(EVENT, "EVENT")
 
 
 class LogInfo:
+    """Helper class to provide "extra" to log records integrated with history.
+
+    This class acts similar to a dict, but with all fields within a dict under a
+    specific key and ensures the fields are json-serializable. Used with the
+    history integration, fields provided will be available in the stored record.
+    This is useful because all fields within extra are placed at the top level
+    of a logrecord dict, so otherwise there is no way to distinguish them.
+
+    Example:
+        self.logger.log(EVENT, "Event message", extra=LogInfo(vial=1))
+        self.logger.info(".", extra={"not_stored": 1, **LogInfo(vial=1).dump()})
+    """
+
     EXTRA_KEY = "evolver_extra"
 
     @staticmethod
@@ -28,13 +41,13 @@ class LogInfo:
     def dump(self):
         return {self.EXTRA_KEY: self._dict}
 
-    def __iter__(self):
+    def __iter__(self):  # to integrate with logging, it inspects keys, then gets items.
         def iter():
             yield self.EXTRA_KEY
 
         return iter()
 
-    def __getitem__(self, _):
+    def __getitem__(self, _):  # for logging, as above.
         return self._dict
 
 

--- a/evolver/logutils.py
+++ b/evolver/logutils.py
@@ -1,3 +1,4 @@
+import json
 import logging
 
 from evolver.settings import settings
@@ -6,19 +7,45 @@ EVENT = logging.INFO + 1
 logging.addLevelName(EVENT, "EVENT")
 
 
+class LogInfo:
+    EXTRA_KEY = "evolver_extra"
+
+    @staticmethod
+    def json_check(data, silent=False):
+        if data == {}:
+            return data
+        try:
+            json.dumps(data)
+            return data
+        except TypeError as e:
+            if silent:
+                return {}
+            raise ValueError(f"Extra data must be json-serializable, got error: {e}")
+
+    def __init__(self, **kwargs):
+        self._dict = __class__.json_check(kwargs)
+
+    def dump(self):
+        return {self.EXTRA_KEY: self._dict}
+
+    def __iter__(self):
+        def iter():
+            yield self.EXTRA_KEY
+
+        return iter()
+
+    def __getitem__(self, _):
+        return self._dict
+
+
 class LogHistoryCaptureHandler(logging.Handler):
     def __init__(self, history_server):
         super().__init__()
         self.history_server = history_server
 
     def emit(self, record):
-        vial = getattr(record, "vial", None)
-        record_dict = {"level": record.levelname, "message": record.getMessage()}
-        # TODO: add support for some extra fields (but these should be
-        # json-seralizable). This might come in the form of named extra data,
-        # expected to be a jsonable dict, e.g. extra={"vial": 1, "extra": ...},
-        # or we could attempt to serialize other fields and include those that
-        # succeed (maybe outside known ones).
+        extra = LogInfo.json_check(getattr(record, LogInfo.EXTRA_KEY, {}), silent=True)
+        record_dict = {"level": record.levelname, "message": record.getMessage(), **extra}
         kind = "event" if record.levelno == EVENT else "log"
         # we strip the package name from logger name since for history logs it
         # is redundant (used here for routing purposes) and without it we can
@@ -26,4 +53,4 @@ class LogHistoryCaptureHandler(logging.Handler):
         name = record.name
         if name.startswith(f"{settings.DEFAULT_LOGGER}."):
             name = name[len(__package__) + 1 :]
-        self.history_server.put(name, kind, record_dict, vial=vial)
+        self.history_server.put(name, kind, record_dict, vial=record_dict.get("vial", None))

--- a/evolver/tests/test_logging.py
+++ b/evolver/tests/test_logging.py
@@ -1,5 +1,7 @@
 import logging
 
+import pytest
+
 from evolver.device import Evolver
 from evolver.hardware.interface import SensorDriver
 from evolver.history.demo import InMemoryHistoryServer
@@ -40,3 +42,13 @@ def test_log_evolver_hookup():
     for logs in history.get(kinds=["log"]).data.values():
         all_messages = [log.data["message"] for log in logs]
         assert test_msg not in all_messages
+
+
+def test_log_info_helper():
+    li = LogInfo(vial=1, event_class="something").dump()
+    assert li == {LogInfo.EXTRA_KEY: {"vial": 1, "event_class": "something"}}
+    assert list(li.keys()) == [LogInfo.EXTRA_KEY]
+    assert li[LogInfo.EXTRA_KEY] == {"vial": 1, "event_class": "something"}
+    with pytest.raises(ValueError):
+        LogInfo(no_json=LogInfo)
+    assert LogInfo.json_check({"no_json": LogInfo}, silent=True) == {}

--- a/evolver/tests/test_logging.py
+++ b/evolver/tests/test_logging.py
@@ -3,7 +3,7 @@ import logging
 from evolver.device import Evolver
 from evolver.hardware.interface import SensorDriver
 from evolver.history.demo import InMemoryHistoryServer
-from evolver.logutils import EVENT, LogHistoryCaptureHandler
+from evolver.logutils import EVENT, LogHistoryCaptureHandler, LogInfo
 
 
 def test_log_capture_handler():
@@ -24,14 +24,14 @@ def test_log_evolver_hookup():
     class HW(SensorDriver):
         def read(self):
             self.logger.warning("test from HW")
-            self.logger.log(EVENT, "event from HW", extra={"vial": 1})
+            self.logger.log(EVENT, "event from HW", extra=LogInfo(vial=1, event_class="something"))
 
     evolver = Evolver(history=history, hardware={"test": HW(name="test")})
     evolver.loop_once()
     log = history.get("test", "log").data["test"][0]
     assert log.data == {"level": "WARNING", "message": "test from HW"}
     event = history.get("test", "event", vials=[1]).data["test"][0]
-    assert event.data == {"level": "EVENT", "message": "event from HW"}
+    assert event.data == {"level": "EVENT", "message": "event from HW", "event_class": "something", "vial": 1}
     assert event.vial == 1
     assert history.get("test", "event", vials=[2]).data["test"] == []
 


### PR DESCRIPTION
This change adds user supplied extra fields to the log, via a helper that does namespacing and validation. 

The namespacing is useful since the logger adds all `extra` fields directly to the log record `__dict__`, which ends up making it impossible to find what was added specifically by the user. The helper here adds fields under a specific keyword to keep this context.

The history endpoint also should expect that data are json serializable (in most general cases), so the helper provides facility to do this. 

In general it can be used like:
```py
logger.info('message', extra=LogInfo(vial=1, arbitrary_info='info'))
```
but provides `dump` in case it needs to be spread into other extra data (which spreads fields under the predefined namespace key):
```py
logger.info('message', extra={'not_saved': 1, **LogInfo(vial=1).dump()})
```

