### PR TITLE
switch json response handler to enable NaN in serialization

### DIFF
--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -4,7 +4,7 @@ from contextlib import asynccontextmanager
 from http import HTTPStatus
 
 from fastapi import FastAPI
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, ORJSONResponse
 from pydantic import ValidationError
 
 import evolver.util
@@ -42,7 +42,7 @@ async def lifespan(app: FastAPI):
     ...
 
 
-app = FastAPI(lifespan=lifespan)
+app = FastAPI(lifespan=lifespan, default_response_class=ORJSONResponse)
 app.state.evolver = None
 
 


### PR DESCRIPTION
FastAPI provides orjson and this looks to be a way that we can allow `NaN` in the json responses. Given passing tests we have some confidence that it produces correct json in other cases.

Resolves #235