### PR TITLE
resume procedure

### DIFF
--- a/.run/evolver-debug-config.run.xml
+++ b/.run/evolver-debug-config.run.xml
@@ -8,13 +8,12 @@
       <env name="PYTHONUNBUFFERED" value="1" />
     </envs>
     <option name="SDK_HOME" value="" />
-    <option name="SDK_NAME" value="Python 3.11 (evolver-ng-env-3.11.0)" />
-    <option name="WORKING_DIRECTORY" value="" />
-    <option name="IS_MODULE_SDK" value="false" />
+    <option name="WORKING_DIRECTORY" value="$ProjectFileDir$" />
+    <option name="IS_MODULE_SDK" value="true" />
     <option name="ADD_CONTENT_ROOTS" value="true" />
     <option name="ADD_SOURCE_ROOTS" value="true" />
     <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
-    <option name="SCRIPT_NAME" value="-m $PROJECT_DIR$" />
+    <option name="SCRIPT_NAME" value="$ProjectFileDir$/evolver/app/main.py" />
     <option name="PARAMETERS" value="" />
     <option name="SHOW_COMMAND_LINE" value="false" />
     <option name="EMULATE_TERMINAL" value="false" />

--- a/evolver/app/exceptions.py
+++ b/evolver/app/exceptions.py
@@ -31,6 +31,13 @@ class CalibratorCalibrationDataNotFoundError(HTTPException):
         )
 
 
+class CalibratorProcedureSaveError(HTTPException):
+    def __init__(self, **kwargs):
+        return super().__init__(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR, detail="Unable to save calibration procedure", **kwargs
+        )
+
+
 class CalibrationProcedureActionNotFoundError(HTTPException):
     def __init__(self, action_name: str, **kwargs):
         return super().__init__(status_code=HTTPStatus.NOT_FOUND, detail=f"Action '{action_name}' not found", **kwargs)

--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -12,15 +12,13 @@ from evolver import __project__, __version__
 from evolver.app.exceptions import CalibratorNotFoundError, HardwareNotFoundError, OperationNotSupportedError
 from evolver.app.html_routes import html_app
 from evolver.app.models import EventInfo, SchemaResponse
+from evolver.app.routers import hardware
 from evolver.base import require_all_fields
 from evolver.device import Evolver
 from evolver.history.interface import HistoryResult
 from evolver.logutils import EVENT, LogInfo
 from evolver.settings import app_settings, settings
 from evolver.types import ImportString
-
-# Import routers
-from .routers import hardware
 
 # Setup logging.
 evolver.util.setup_logging()

--- a/evolver/app/routers/hardware.py
+++ b/evolver/app/routers/hardware.py
@@ -78,6 +78,10 @@ def start_calibration_procedure(
     request: Request,
     resume: bool = Query(True),
 ):
+    # TODO: if resume is false, require a file name to save the procedure state to. and update the calibration_file attribute in the Calibrator config accordingly.
+    # Otherwise, starting a procedure with resume to false risks destroying the state of the procedure (if any in the exisiting calibration_file).
+    # For now we will just raise an error if resume is false and no calibration_file is provided.
+    # normally the calibration_file will be empty of any procedure state and so resuming by default is fine.
     hardware_instance = get_hardware_instance(request, hardware_name)
     calibrator = hardware_instance.calibrator
     if not calibrator:
@@ -88,7 +92,7 @@ def start_calibration_procedure(
         resume=resume,
     )
 
-    return calibrator.calibration_procedure.get_state()
+    return {**calibrator.calibration_procedure.get_state(), "started": True}
 
 
 # Get available actions for the calibration procedure

--- a/evolver/app/routers/hardware.py
+++ b/evolver/app/routers/hardware.py
@@ -8,9 +8,9 @@ from evolver.app.exceptions import (
     CalibrationProcedureActionNotFoundError,
     CalibratorCalibrationDataNotFoundError,
     CalibratorNotFoundError,
+    CalibratorProcedureSaveError,
     EvolverNotFoundError,
     HardwareNotFoundError,
-    CalibratorProcedureSaveError,
 )
 from evolver.hardware.interface import HardwareDriver
 

--- a/evolver/app/routers/hardware.py
+++ b/evolver/app/routers/hardware.py
@@ -193,7 +193,6 @@ def get_calibration_data(hardware_name: str, request: Request):
     if not calibrator.calibration_data:
         raise CalibratorCalibrationDataNotFoundError
 
-    foo = calibrator.calibration_data
     return calibrator.calibration_data
 
 

--- a/evolver/app/routers/hardware.py
+++ b/evolver/app/routers/hardware.py
@@ -183,7 +183,7 @@ def save_calibration_procedure(hardware_name: str, request: Request):
 
 
 # Get the calibrator's CalibrationData, representing the state from the procedure that has been saved
-# This data will appear in the config file even if the procedure is interupted. And will be used as the initial state when the procedure is resumed.
+# This data will appear in the config file even if the procedure is interrupted. And will be used as the initial state when the procedure is resumed.
 @router.get("/{hardware_name}/calibrator/data")
 def get_calibration_data(hardware_name: str, request: Request):
     hardware_instance = get_hardware_instance(request, hardware_name)
@@ -193,6 +193,7 @@ def get_calibration_data(hardware_name: str, request: Request):
     if not calibrator.calibration_data:
         raise CalibratorCalibrationDataNotFoundError
 
+    foo = calibrator.calibration_data
     return calibrator.calibration_data
 
 

--- a/evolver/app/routers/hardware.py
+++ b/evolver/app/routers/hardware.py
@@ -79,9 +79,7 @@ def start_calibration_procedure(
     resume: bool = Query(True),
 ):
     # TODO: if resume is false, require a file name to save the procedure state to. and update the calibration_file attribute in the Calibrator config accordingly.
-    # Otherwise, starting a procedure with resume to false risks destroying the state of the procedure (if any in the exisiting calibration_file).
-    # For now we will just raise an error if resume is false and no calibration_file is provided.
-    # normally the calibration_file will be empty of any procedure state and so resuming by default is fine.
+    # Otherwise, starting a procedure with resume to false risks destroying the state of the procedure (if any in the existing calibration_file).
     hardware_instance = get_hardware_instance(request, hardware_name)
     calibrator = hardware_instance.calibrator
     if not calibrator:

--- a/evolver/app/tests/test_calibration.py
+++ b/evolver/app/tests/test_calibration.py
@@ -1,3 +1,5 @@
+from unittest.mock import MagicMock
+
 from fastapi.testclient import TestClient
 
 from evolver.app.main import app
@@ -9,7 +11,7 @@ from evolver.hardware.demo import NoOpSensorDriver
 from evolver.tests.conftest import tmp_calibration_dir  # noqa: F401
 
 
-def setup_evolver_with_calibrator(calibrator_class, hardware_name="test", vials=[0, 1, 2]):
+def setup_evolver_with_calibrator(calibrator_class, hardware_name="test", vials=[0, 1, 2], calibration_file=None):
     calibrator = calibrator_class(
         input_transformer={
             0: LinearTransformer("Test Transformer"),
@@ -21,6 +23,7 @@ def setup_evolver_with_calibrator(calibrator_class, hardware_name="test", vials=
             1: LinearTransformer(),
             2: LinearTransformer(),
         },
+        calibration_file=calibration_file,
     )
     evolver_instance = Evolver(
         hardware={hardware_name: NoOpSensorDriver(name=hardware_name, calibrator=calibrator, vials=vials)}
@@ -145,6 +148,47 @@ def test_calibration_procedure_undo_action_utility():
     undo_response = client.post("/hardware/test/calibrator/procedure/undo")
     assert undo_response.status_code == 200
     assert undo_response.json() == {"completed_actions": [], "history": [], "started": True}
+
+
+def test_calibration_procedure_save(tmp_path):
+    # Setup
+    cal_file = tmp_path / "calibration.yml"
+    cal_file.touch()
+
+    _, client = setup_evolver_with_calibrator(TemperatureCalibrator, calibration_file=str(cal_file))
+    app.state.evolver.hardware["test"].read = lambda: [1.23, 2.34, 3.45]
+
+    # Start procedure
+    client.post("/hardware/test/calibrator/procedure/start")
+
+    # Dispatch an action to have something to save
+    dispatch_response = dispatch_action(client, "test", "read_vial_0_raw_output")
+    assert dispatch_response.status_code == 200
+
+    # Test successful save
+    save_response = client.post("/hardware/test/calibrator/procedure/save")
+    assert save_response.status_code == 200
+    assert save_response.json() == {
+        "0": {"raw": [1.23], "reference": []},
+        "completed_actions": ["read_vial_0_raw_output"],
+        "history": [{"completed_actions": [], "history": []}],
+        "started": True,
+    }
+
+    # Test save with no calibrator
+    no_calibrator_response = client.post("/hardware/nonexistent/calibrator/procedure/save")
+    assert no_calibrator_response.status_code == 404
+
+    # Test save with no procedure started
+    app.state.evolver.hardware["test"].calibrator.calibration_procedure = None
+    no_procedure_response = client.post("/hardware/test/calibrator/procedure/save")
+    assert no_procedure_response.json() == {"started": False}
+
+    # Test save failure
+    app.state.evolver.hardware["test"].calibrator.calibration_procedure = MagicMock()
+    app.state.evolver.hardware["test"].calibrator.calibration_procedure.save.side_effect = Exception
+    error_response = client.post("/hardware/test/calibrator/procedure/save")
+    assert error_response.status_code == 500
 
 
 def test_dispatch_temperature_calibration_calculate_fit_action():

--- a/evolver/app/tests/test_calibration.py
+++ b/evolver/app/tests/test_calibration.py
@@ -44,7 +44,7 @@ class TestCalibration:
     def test_get_calibration_status(self):
         _, client = setup_evolver_with_calibrator(NoOpCalibrator)
 
-        response = client.post("/hardware/test/calibrator/procedure/start")
+        response = client.post("/hardware/test/calibrator/procedure/start", params={"resume": False})
         assert response.status_code == 200
 
         response = client.get("/hardware/test/calibrator/procedure/state")
@@ -62,7 +62,7 @@ class TestCalibration:
 def test_temperature_calibration_procedure_actions():
     temp_calibrator, client = setup_evolver_with_calibrator(TemperatureCalibrator)
 
-    response = client.post("/hardware/test/calibrator/procedure/start")
+    response = client.post("/hardware/test/calibrator/procedure/start", params={"resume": False})
     assert response.status_code == 200
 
     actions_response = client.get("/hardware/test/calibrator/procedure/actions")
@@ -94,7 +94,7 @@ def test_temperature_calibration_procedure_actions_not_started():
 def test_dispatch_temperature_calibration_bad_reference_value_action():
     _, client = setup_evolver_with_calibrator(TemperatureCalibrator)
 
-    client.post("/hardware/test/calibrator/procedure/start")
+    client.post("/hardware/test/calibrator/procedure/start", params={"resume": False})
 
     action_payload = {"action_name": "measure_vial_0_temperature", "payload": {"this_should_not_work": 25.0}}
     dispatch_response = dispatch_action(client, "test", "measure_vial_0_temperature", action_payload["payload"])
@@ -107,7 +107,7 @@ def test_dispatch_temperature_calibration_raw_value_action():
 
     app.state.evolver.hardware["test"].read = lambda: [1.23, 2.34, 3.45]
 
-    client.post("/hardware/test/calibrator/procedure/start")
+    client.post("/hardware/test/calibrator/procedure/start", params={"resume": False})
 
     raw_dispatch_response = dispatch_action(client, "test", "read_vial_0_raw_output")
 
@@ -125,14 +125,14 @@ def test_reset_calibration_procedure():
 
     app.state.evolver.hardware["test"].read = lambda: [1.23, 2.34, 3.45]
 
-    client.post("/hardware/test/calibrator/procedure/start")
+    client.post("/hardware/test/calibrator/procedure/start", params={"resume": False})
 
     raw_dispatch_response = dispatch_action(client, "test", "read_vial_0_raw_output")
     assert raw_dispatch_response.status_code == 200
 
-    reset_response = client.post("/hardware/test/calibrator/procedure/start", json={"resume": False})
+    reset_response = client.post("/hardware/test/calibrator/procedure/start", params={"resume": False})
     assert reset_response.status_code == 200
-    assert reset_response.json() == {"completed_actions": [], "history": []}
+    assert reset_response.json() == {"completed_actions": [], "history": [], "started": True}
 
 
 def test_calibration_procedure_undo_action_utility():
@@ -140,7 +140,7 @@ def test_calibration_procedure_undo_action_utility():
 
     app.state.evolver.hardware["test"].read = lambda: [1.23, 2.34, 3.45]
 
-    client.post("/hardware/test/calibrator/procedure/start")
+    client.post("/hardware/test/calibrator/procedure/start", params={"resume": False})
 
     dispatch_response = dispatch_action(client, "test", "read_vial_0_raw_output")
     assert dispatch_response.status_code == 200
@@ -159,7 +159,7 @@ def test_calibration_procedure_save(tmp_path):
     app.state.evolver.hardware["test"].read = lambda: [1.23, 2.34, 3.45]
 
     # Start procedure
-    client.post("/hardware/test/calibrator/procedure/start")
+    client.post("/hardware/test/calibrator/procedure/start", params={"resume": False})
 
     # Dispatch an action to have something to save
     dispatch_response = dispatch_action(client, "test", "read_vial_0_raw_output")
@@ -226,7 +226,7 @@ def test_dispatch_temperature_calibration_calculate_fit_action():
 
     app.state.evolver.hardware["test"].read = lambda: [1.23, 2.34, 3.45]
 
-    client.post("/hardware/test/calibrator/procedure/start")
+    client.post("/hardware/test/calibrator/procedure/start", params={"resume": False})
 
     reference_dispatch_response = dispatch_action(client, "test", "measure_vial_0_temperature", {"temperature": 25.0})
     assert reference_dispatch_response.status_code == 200
@@ -251,7 +251,7 @@ def test_get_calibration_data(tmp_path):
 
     app.state.evolver.hardware["test"].read = lambda: [1.23, 2.34, 3.45]
 
-    client.post("/hardware/test/calibrator/procedure/start")
+    client.post("/hardware/test/calibrator/procedure/start", params={"resume": False})
 
     dispatch_action(client, "test", "measure_vial_0_temperature", {"temperature": 25.0})
     dispatch_action(client, "test", "read_vial_0_raw_output")
@@ -265,7 +265,7 @@ def test_get_calibration_data(tmp_path):
     assert calibration_data_response.status_code == 200
     calibration_data = calibration_data_response.json()
 
-    assert calibration_data["measured"] == {
+    assert calibration_data["procedure_state"] == {
         "0": {"raw": [1.23], "reference": [25.0]},
         "completed_actions": ["measure_vial_0_temperature", "read_vial_0_raw_output", "calculate_vial_0_fit"],
         "history": [

--- a/evolver/calibration/action.py
+++ b/evolver/calibration/action.py
@@ -1,5 +1,4 @@
 from abc import ABC, abstractmethod
-from functools import wraps
 from typing import Dict, Optional
 
 from pydantic import BaseModel
@@ -56,17 +55,6 @@ class CalibrationAction(ABC):
         pass
 
 
-def save(action):
-    @wraps(action)
-    def wrapper(self, state: Dict, *args, **kwargs):
-        updated_state = action(self, state, *args, **kwargs)
-        self.hardware.calibrator.calibration_data.measured = updated_state
-        self.hardware.calibrator.calibration_data.save()
-        return updated_state
-
-    return wrapper
-
-
 class DisplayInstructionAction(CalibrationAction):
     class FormModel(BaseModel):
         pass
@@ -74,6 +62,5 @@ class DisplayInstructionAction(CalibrationAction):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-    @save  # This action, when dispatched, will save the procedure state to the Calibrator.CalibrationData class
     def execute(self, state: Dict, payload: Optional[FormModel] = None):
         return state.copy()

--- a/evolver/calibration/demo.py
+++ b/evolver/calibration/demo.py
@@ -32,6 +32,6 @@ class NoOpCalibrator(Calibrator):
         *args,
         **kwargs,
     ):
-        calibration_procedure = CalibrationProcedure()
+        calibration_procedure = CalibrationProcedure(hardware=selected_hardware)
         self.calibration_procedure = calibration_procedure
         pass

--- a/evolver/calibration/interface.py
+++ b/evolver/calibration/interface.py
@@ -60,9 +60,13 @@ class Transformer(BaseInterface):
 
         def save(
             self,
-            file_path: Path,
+            file_path: Path = None,
             encoding: str | None = None,
         ):
+            if file_path is None:
+                file_path = Path(f"{self.name}_{self.created.strftime(settings.DATETIME_PATH_FORMAT)}").with_suffix(
+                    ".yml"
+                )
             return super().save(file_path=self.dir / file_path, encoding=encoding)
 
     @abstractmethod

--- a/evolver/calibration/interface.py
+++ b/evolver/calibration/interface.py
@@ -60,13 +60,9 @@ class Transformer(BaseInterface):
 
         def save(
             self,
-            file_path: Path = None,
+            file_path: Path,
             encoding: str | None = None,
         ):
-            if file_path is None:
-                file_path = Path(f"{self.name}_{self.created.strftime(settings.DATETIME_PATH_FORMAT)}").with_suffix(
-                    ".yml"
-                )
             return super().save(file_path=self.dir / file_path, encoding=encoding)
 
     @abstractmethod

--- a/evolver/calibration/interface.py
+++ b/evolver/calibration/interface.py
@@ -14,7 +14,6 @@ from evolver.base import (
     TimeStamp,
     _BaseConfig,
 )
-from evolver.calibration.procedure import CalibrationStateModel
 from evolver.settings import settings
 
 if TYPE_CHECKING:
@@ -119,9 +118,8 @@ class Calibrator(BaseInterface):
         output_transformer: ConfigDescriptor | Transformer | None = None
         calibration_file: str | None = None
 
-    class CalibrationData(Transformer.Config, CalibrationStateModel):
-        """Stores calibration data, including the completed_actions and the "measured" data the actions have collected
-        from the CalibrationProcedure."""
+    class CalibrationData(Transformer.Config):
+        """Stores calibration data, inculding the procedure_state from the calibration_procedure."""
 
     class Status(_BaseConfig):
         input_transformer: Status | None = None

--- a/evolver/calibration/procedure.py
+++ b/evolver/calibration/procedure.py
@@ -91,6 +91,7 @@ class CalibrationProcedure(BaseInterface, ABC):
         # calibration_file maybe none, in which case the save operation must fail with an error message.
         if file_path is None:
             raise ValueError("calibration_file attribute is not set on the Calibrator config.")
+        self.hardware.calibrator.calibration_data.measured = self.state
         self.hardware.calibrator.calibration_data.save(file_path)
         return self.state
 

--- a/evolver/calibration/procedure.py
+++ b/evolver/calibration/procedure.py
@@ -30,7 +30,7 @@ class CalibrationStateModel(BaseModel):
 class CalibrationProcedure(BaseInterface, ABC):
     class Config(BaseInterface.Config): ...
 
-    def __init__(self, state=None, *args, **kwargs):
+    def __init__(self, hardware, state=None, *args, **kwargs):
         """
         Initialize the CalibrationProcedure.
 
@@ -42,7 +42,7 @@ class CalibrationProcedure(BaseInterface, ABC):
                 The state can be saved and reloaded to continue the calibration procedure if interrupted.
                 To save the state to the Calibrator.CalibrationData class, decorate an action's execute method with the @save decorator.
                 Only state that is explicitly saved will be persisted, so it is important to save the state periodically.
-                The @save decorator persists the entire state of the procedure, after @save decorated action has been executed.
+            hardware (HardwareDriver): The hardware that the calibration procedure will interact with.
 
         Notes:
             Dispatching an action will update the state of the calibration procedure.
@@ -56,6 +56,7 @@ class CalibrationProcedure(BaseInterface, ABC):
         super().__init__(*args, **kwargs)
         self.actions = []
         self.state = CalibrationStateModel(**(state or {})).model_dump()
+        self.hardware = hardware
 
     def add_action(self, action: CalibrationAction):
         if any(existing_action.name == action.name for existing_action in self.actions):
@@ -74,9 +75,23 @@ class CalibrationProcedure(BaseInterface, ABC):
     def undo(self):
         """
         Undo the last action that was dispatched in the calibration procedure.
+        Note, if you dispatch an action decorated with the @save decorator, and then undo it, the saved representation of the procedure state will not reflect the undone action.
         """
         if len(self.state["history"]) > 0:
             self.state = self.state["history"].pop()
+        return self.state
+
+    def save(self):
+        """
+        Save the current state of the calibration procedure, to a file.
+        The CalibrationData class, because it inherits from the Transformer class has a save method that saves its state to a file.
+        NOTE: Currently this is everything in CalibrationData, maybe it should just be the "measured" attribute.
+        """
+        file_path = self.hardware.calibrator.calibration_file
+        # calibration_file maybe none, in which case the save operation must fail with an error message.
+        if file_path is None:
+            raise ValueError("calibration_file attribute is not set on the Calibrator config.")
+        self.hardware.calibrator.calibration_data.save(file_path)
         return self.state
 
     def dispatch(self, action: CalibrationAction, payload: Dict[str, Any]):

--- a/evolver/calibration/procedure.py
+++ b/evolver/calibration/procedure.py
@@ -10,10 +10,9 @@ from evolver.calibration.action import CalibrationAction
 
 class CalibrationStateModel(BaseModel):
     """
-    Model to represent the state of a calibration procedure. All procedures record their completed actions in this model.
-    Along with the completed actions, the state of the calibration procedure (i.e. the data the actions have gathered) can be stored.
-    The shape of this additional data is not fixed and therefore is not included in the model here.
-    When considering adding attributes, note this model is shared by the Calibrator.CalibrationData class.
+    Model to represent the state of a calibration procedure. All procedures record their completed actions, and history of actions in this model.
+    The data collected by the calibration procedure (i.e. the data the actions have gathered, that's used as input to the Hardware.input/outputTransformer methods) is also stored here.
+    The shape of this additional data, sometimes referred to a "measured" is not fixed and therefore is not included in the model here.
 
     Attributes:
         completed_actions (List[str]): A list of actions that have been completed during the calibration procedure.
@@ -88,7 +87,11 @@ class CalibrationProcedure(BaseInterface, ABC):
         # calibration_file maybe none, in which case the save operation must fail with an error message.
         if file_path is None:
             raise ValueError("calibration_file attribute is not set on the Calibrator config.")
-        self.hardware.calibrator.calibration_data.measured = self.state
+        self.hardware.calibrator.calibration_data.procedure_state = {**self.state}
+        """
+        self.hardware.calibrator.calibration_data.history = self.state.get("history", [])
+        self.hardware.calibrator.calibration_data.completed_actions = self.state.get("completed_actions", [])
+        """
         self.hardware.calibrator.calibration_data.save(file_path)
         return self.state
 

--- a/evolver/calibration/procedure.py
+++ b/evolver/calibration/procedure.py
@@ -40,7 +40,6 @@ class CalibrationProcedure(BaseInterface, ABC):
                 Typically, a procedure is complete when all actions have been dispatched in sequence using the HTTP API.
             state (CalibrationStateModel): The state of the calibration procedure updated as actions are executed.
                 The state can be saved and reloaded to continue the calibration procedure if interrupted.
-                To save the state to the Calibrator.CalibrationData class, decorate an action's execute method with the @save decorator.
                 Only state that is explicitly saved will be persisted, so it is important to save the state periodically.
             hardware (HardwareDriver): The hardware that the calibration procedure will interact with.
 
@@ -75,7 +74,6 @@ class CalibrationProcedure(BaseInterface, ABC):
     def undo(self):
         """
         Undo the last action that was dispatched in the calibration procedure.
-        Note, if you dispatch an action decorated with the @save decorator, and then undo it, the saved representation of the procedure state will not reflect the undone action.
         """
         if len(self.state["history"]) > 0:
             self.state = self.state["history"].pop()
@@ -85,7 +83,6 @@ class CalibrationProcedure(BaseInterface, ABC):
         """
         Save the current state of the calibration procedure, to a file.
         The CalibrationData class, because it inherits from the Transformer class has a save method that saves its state to a file.
-        NOTE: Currently this is everything in CalibrationData, maybe it should just be the "measured" attribute.
         """
         file_path = self.hardware.calibrator.calibration_file
         # calibration_file maybe none, in which case the save operation must fail with an error message.

--- a/evolver/calibration/standard/actions/temperature.py
+++ b/evolver/calibration/standard/actions/temperature.py
@@ -14,9 +14,8 @@ class ReferenceValueAction(CalibrationAction):
 
         temperature: float = Field(..., title="Temperature", description="Temperature in degrees Celsius")
 
-    def __init__(self, hardware, vial_idx: int, *args, **kwargs):
+    def __init__(self, vial_idx: int, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.hardware = hardware
         self.vial_idx = vial_idx
 
     def execute(self, state: Dict, payload: Optional[FormModel] = None):
@@ -29,9 +28,8 @@ class RawValueAction(CalibrationAction):
     class FormModel(BaseModel):
         pass
 
-    def __init__(self, hardware, vial_idx: int, *args, **kwargs):
+    def __init__(self, vial_idx: int, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.hardware = hardware
         self.vial_idx = vial_idx
 
     def execute(self, state, payload: Optional[FormModel] = None):
@@ -45,9 +43,8 @@ class CalculateFitAction(CalibrationAction):
     class FormModel(BaseModel):
         pass
 
-    def __init__(self, hardware, vial_idx: int, *args, **kwargs):
+    def __init__(self, vial_idx: int, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.hardware = hardware
         self.vial_idx = vial_idx
 
     @save  # This action, when dispatched, will save the procedure state to the Calibrator.CalibrationData class

--- a/evolver/calibration/standard/actions/temperature.py
+++ b/evolver/calibration/standard/actions/temperature.py
@@ -52,6 +52,6 @@ class CalculateFitAction(CalibrationAction):
         vial_data = state[self.vial_idx]
         # Side effect: refit the output transformer with the new data, store refit in another class.
         # The result of the refit is stored in the output_transformer, accessible via hardware.calibrator.output_transformer
-        # TODO: make fit a method of the procedure (like undo and save), not the action, so that the procedure actions are all idempotent.
+        # TODO: mak fit a method of the procedure (like undo and save), not the action, so that the procedure actions are all idempotent.
         self.hardware.calibrator.output_transformer[self.vial_idx].refit(vial_data["reference"], vial_data["raw"])
         return state

--- a/evolver/calibration/standard/actions/temperature.py
+++ b/evolver/calibration/standard/actions/temperature.py
@@ -2,7 +2,7 @@ from typing import Dict, Optional
 
 from pydantic import BaseModel, Field
 
-from evolver.calibration.action import CalibrationAction, save
+from evolver.calibration.action import CalibrationAction
 
 
 class ReferenceValueAction(CalibrationAction):
@@ -47,11 +47,11 @@ class CalculateFitAction(CalibrationAction):
         super().__init__(*args, **kwargs)
         self.vial_idx = vial_idx
 
-    @save  # This action, when dispatched, will save the procedure state to the Calibrator.CalibrationData class
     def execute(self, state, payload: Optional[FormModel] = None):
         state.setdefault(self.vial_idx, {"reference": [], "raw": []})
         vial_data = state[self.vial_idx]
         # Side effect: refit the output transformer with the new data, store refit in another class.
         # The result of the refit is stored in the output_transformer, accessible via hardware.calibrator.output_transformer
+        # TODO: make fit a method of the procedure (like undo and save), not the action, so that the procedure actions are all idempotent.
         self.hardware.calibrator.output_transformer[self.vial_idx].refit(vial_data["reference"], vial_data["raw"])
         return state

--- a/evolver/calibration/standard/calibrators/temperature.py
+++ b/evolver/calibration/standard/calibrators/temperature.py
@@ -34,7 +34,9 @@ class TemperatureCalibrator(IndependentVialBasedCalibrator):
         }
 
         calibration_procedure = (
-            CalibrationProcedure(persisted_state) if resume and persisted_state else CalibrationProcedure()
+            CalibrationProcedure(state=persisted_state, hardware=selected_hardware)
+            if resume and persisted_state
+            else CalibrationProcedure(hardware=selected_hardware)
         )
 
         calibration_procedure.add_action(

--- a/evolver/calibration/standard/calibrators/temperature.py
+++ b/evolver/calibration/standard/calibrators/temperature.py
@@ -25,9 +25,12 @@ class TemperatureCalibrator(IndependentVialBasedCalibrator):
         *args,
         **kwargs,
     ):
-        # Cherrypick data persisted to Calibrator.CalibrationData, to resume the CalibrationProcedure from the last saved state.
-        # Convert CalibrationStateModel to dict before unpacking
-        procedure_state = self.calibration_data.procedure_state.model_dump() if resume else None
+        procedure_state = self.calibration_data.procedure_state
+        if resume and procedure_state == {}:
+            procedure_state = None
+        else:
+            # resume procedure state from the data stored at the hardware.calibrator.dir/hardware.calibrator.calibration_file location defined in config
+            procedure_state = procedure_state.model_dump() if resume else None
 
         calibration_procedure = CalibrationProcedure(state=procedure_state, hardware=selected_hardware)
 

--- a/evolver/calibration/standard/calibrators/temperature.py
+++ b/evolver/calibration/standard/calibrators/temperature.py
@@ -38,7 +38,9 @@ class TemperatureCalibrator(IndependentVialBasedCalibrator):
         )
 
         calibration_procedure.add_action(
-            DisplayInstructionAction(description="Fill each vial with 15ml water", name="fill_vials_instruction")
+            DisplayInstructionAction(
+                description="Fill each vial with 15ml water", name="fill_vials_instruction", hardware=selected_hardware
+            )
         )
         for vial in self.vials:
             calibration_procedure.add_action(

--- a/evolver/calibration/standard/calibrators/temperature.py
+++ b/evolver/calibration/standard/calibrators/temperature.py
@@ -1,8 +1,6 @@
-from typing import Dict, List
-
 from evolver.calibration.action import DisplayInstructionAction
 from evolver.calibration.interface import Calibrator, IndependentVialBasedCalibrator
-from evolver.calibration.procedure import CalibrationProcedure
+from evolver.calibration.procedure import CalibrationProcedure, CalibrationStateModel
 from evolver.calibration.standard.actions.temperature import (
     CalculateFitAction,
     RawValueAction,
@@ -17,7 +15,7 @@ class TemperatureCalibrator(IndependentVialBasedCalibrator):
     """
 
     class CalibrationData(Calibrator.CalibrationData):
-        measured: Dict[int, Dict[str, List[float]]] = {}  # {vial_index: {"reference": [], "raw": []}}
+        procedure_state: CalibrationStateModel = {}
 
     def create_calibration_procedure(
         self,
@@ -28,16 +26,10 @@ class TemperatureCalibrator(IndependentVialBasedCalibrator):
         **kwargs,
     ):
         # Cherrypick data persisted to Calibrator.CalibrationData, to resume the CalibrationProcedure from the last saved state.
-        persisted_state = {
-            **self.calibration_data.measured,
-            "completed_actions": self.calibration_data.completed_actions,
-        }
+        # Convert CalibrationStateModel to dict before unpacking
+        procedure_state = self.calibration_data.procedure_state.model_dump() if resume else None
 
-        calibration_procedure = (
-            CalibrationProcedure(state=persisted_state, hardware=selected_hardware)
-            if resume and persisted_state
-            else CalibrationProcedure(hardware=selected_hardware)
-        )
+        calibration_procedure = CalibrationProcedure(state=procedure_state, hardware=selected_hardware)
 
         calibration_procedure.add_action(
             DisplayInstructionAction(

--- a/evolver/calibration/standard/calibrators/temperature.py
+++ b/evolver/calibration/standard/calibrators/temperature.py
@@ -44,6 +44,15 @@ class TemperatureCalibrator(IndependentVialBasedCalibrator):
                 description="Fill each vial with 15ml water", name="fill_vials_instruction", hardware=selected_hardware
             )
         )
+
+        calibration_procedure.add_action(
+            DisplayInstructionAction(
+                description="Wait 25 mins for equilibrium",
+                name="wait_for_equilibrium_instruction",
+                hardware=selected_hardware,
+            )
+        )
+
         for vial in self.vials:
             calibration_procedure.add_action(
                 ReferenceValueAction(


### PR DESCRIPTION
Includes all the work from PR: #249 - Calibration save endpoint

^ I strongly suggest reviewing that first, then the diff on this PR will be more concise.

Plus

Working calibration procedure resume functionality and tests.

With this when a calibration procedure is passed the "resume=True" param when it is started, it will load calibration procedure state from the Calibrator.CalibrationData class (a config object stored on FS).

This means:  if a procedure is interrupted a calibration procedure will be resumable from the last saved state