### PR TITLE
falling back to None for uncalibrated values, iso raw value

### DIFF
--- a/evolver/hardware/demo.py
+++ b/evolver/hardware/demo.py
@@ -11,7 +11,7 @@ class NoOpSensorDriver(SensorDriver):
 
     class Output(SensorDriver.Output):
         raw: int
-        value: int
+        value: int | None = None
 
     def read(self):
         """Simulate reading data from sensors, applying transformations if a calibrator is present."""

--- a/evolver/hardware/interface.py
+++ b/evolver/hardware/interface.py
@@ -26,7 +26,7 @@ class HardwareDriver(BaseInterface):
         self.evolver = evolver
         super().__init__(*args, **kwargs)
 
-    def _transform(self, transformer: str, func: str, x: Any, vial: int = None):
+    def _transform(self, transformer: str, func: str, x: Any, vial: int = None, fallback=None):
         """Helper func to reduce boilerplate when transforming input and output data."""
         if self.calibrator and (_transformer := getattr(self.calibrator, transformer, None)):
             if isinstance(_transformer, dict):
@@ -34,7 +34,7 @@ class HardwareDriver(BaseInterface):
             else:
                 y = getattr(_transformer, func)(x)
         else:
-            y = x
+            y = fallback
 
         return y
 

--- a/evolver/hardware/standard/tests/test_standard.py
+++ b/evolver/hardware/standard/tests/test_standard.py
@@ -1,5 +1,6 @@
 import pytest
 
+from evolver.calibration.demo import NoOpCalibrator
 from evolver.calibration.interface import Calibrator, Transformer
 from evolver.hardware.standard.led import LED
 from evolver.hardware.standard.od_sensor import OD90, ODSensor
@@ -135,12 +136,12 @@ class TestStir(SerialVialEffectorHardwareTestSuite):
     "config_params, values, serial_out",
     [
         (
-            {"addr": "pump", "slots": 2},
+            {"addr": "pump", "slots": 2, "calibrator": NoOpCalibrator()},
             [[VialIEPump.Input(vial=0, influx_volume=1, efflux_volume=2)]],
             [b"pumpr,1.0|0,--,2.0|0,--,--,--,_!"],
         ),
         (
-            {"addr": "pump", "slots": 2},
+            {"addr": "pump", "slots": 2, "calibrator": NoOpCalibrator()},
             [
                 [
                     VialIEPump.Input(vial=0, influx_volume=1, influx_rate=2, efflux_volume=3, efflux_rate=4),
@@ -150,7 +151,14 @@ class TestStir(SerialVialEffectorHardwareTestSuite):
             [b"pumpr,1.0|1800,1.0|1800,3.0|900,3.0|900,--,--,_!"],
         ),
         (
-            {"addr": "pump", "ipp_pumps": [0, 1], "slots": 2, "influx_map": {0: 0}, "efflux_map": {0: 1}},
+            {
+                "addr": "pump",
+                "ipp_pumps": [0, 1],
+                "slots": 2,
+                "influx_map": {0: 0},
+                "efflux_map": {0: 1},
+                "calibrator": NoOpCalibrator(),
+            },
             [[VialIEPump.Input(vial=0, influx_volume=1, efflux_volume=2)]],
             [b"pumpr,1.0|0|1,1.0|0|2,1.0|0|3,2.0|1|1,2.0|1|2,2.0|1|3,_!"],
         ),


### PR DESCRIPTION
Implemented as a configurable fallback value which defaults to `None`

resolves #263 