### PR TITLE
separate ongoing procedure file from applied calibration file

### DIFF
--- a/evolver/app/tests/test_calibration.py
+++ b/evolver/app/tests/test_calibration.py
@@ -292,7 +292,6 @@ def get_stable_state_subset(state):
 def test_get_calibration_data(tmp_path):
     # Setup fs for save.
     cal_file = tmp_path / "calibration.yml"
-    cal_file.touch()
 
     temp_calibrator, client = setup_evolver_with_calibrator(TemperatureCalibrator, procedure_file=str(cal_file))
 

--- a/evolver/calibration/interface.py
+++ b/evolver/calibration/interface.py
@@ -139,7 +139,10 @@ class Calibrator(BaseInterface):
     class Config(Transformer.Config):
         input_transformer: ConfigDescriptor | Transformer | None = None
         output_transformer: ConfigDescriptor | Transformer | None = None
-        calibration_file: str | None = None
+        calibration_file: str | None = Field(None, description="Completed calibration file to use for transformations")
+        procedure_file: str | None = Field(
+            None, description="Working calibration file for currently active (or next) procedure"
+        )
 
     class Status(_BaseConfig):
         input_transformer: Status | None = None

--- a/evolver/calibration/procedure.py
+++ b/evolver/calibration/procedure.py
@@ -65,10 +65,10 @@ class CalibrationProcedure(BaseInterface, ABC):
         The calibration_data attribute on the Calibrator, because it is a CalibrationStateModel, it inherits from the Transformer class has a save method that saves its state to a file.
         The file the state is saved to is defined in the Calibrator's config, specifically calibrator.dir/calibrator.calibration_file.
         """
-        file_path = self.hardware.calibrator.calibration_file
+        file_path = self.hardware.calibrator.procedure_file
         # calibration_file maybe none, in which case the save operation must fail with an error message.
         if file_path is None:
-            raise ValueError("calibration_file attribute is not set on the Calibrator config.")
+            raise ValueError("procedure_file attribute is not set on the Calibrator config.")
         self.hardware.calibrator.calibration_data = self.state
         self.hardware.calibrator.calibration_data.save(file_path)
         return self.state

--- a/evolver/calibration/standard/calibrators/temperature.py
+++ b/evolver/calibration/standard/calibrators/temperature.py
@@ -1,5 +1,5 @@
 from evolver.calibration.action import DisplayInstructionAction
-from evolver.calibration.interface import IndependentVialBasedCalibrator
+from evolver.calibration.interface import CalibrationStateModel, IndependentVialBasedCalibrator
 from evolver.calibration.procedure import CalibrationProcedure
 from evolver.calibration.standard.actions.temperature import (
     CalculateFitAction,
@@ -22,7 +22,7 @@ class TemperatureCalibrator(IndependentVialBasedCalibrator):
         *args,
         **kwargs,
     ):
-        procedure_state = self.calibration_data if resume else None
+        procedure_state = CalibrationStateModel.load(self.procedure_file) if resume else None
         calibration_procedure = CalibrationProcedure(
             state=procedure_state.model_dump() if procedure_state else None, hardware=selected_hardware
         )


### PR DESCRIPTION
Keep ongoing/partial procedure state to a separate file to avoid startup conflict with calibration file loading (if specified, the calibration file expects a complete file to load at startup, but the procedure necessarily expects and empty one at start, or a partial one at resume).

Resolves #261 