### PR TITLE
Store fitted calibrator in state model, path to load, and default transformers

### DIFF
--- a/evolver/calibration/demo.py
+++ b/evolver/calibration/demo.py
@@ -13,6 +13,10 @@ class NoOpTransformer(Transformer):
     def convert_to(self, data, *args, **kwargs):
         return data
 
+    def refit(self, *args, **kwargs):
+        self._refit_args = args
+        self._refit_kwargs = kwargs
+
     convert_from = convert_to
 
 

--- a/evolver/calibration/demo.py
+++ b/evolver/calibration/demo.py
@@ -7,6 +7,9 @@ from evolver.hardware.interface import HardwareDriver
 
 
 class NoOpTransformer(Transformer):
+    class Config(Transformer.Config):
+        param1: float = Field(default=1.0)
+
     def convert_to(self, data, *args, **kwargs):
         return data
 

--- a/evolver/calibration/interface.py
+++ b/evolver/calibration/interface.py
@@ -238,8 +238,8 @@ class IndependentVialBasedCalibrator(Calibrator, ABC):
 
     def get_input_transformer(self, vial):
         """Get the input transformer for a given vial."""
-        return self.input_transformer.setdefault(vial, copy(self.default_input_transformer))
+        return self.input_transformer.setdefault(int(vial), copy(self.default_input_transformer))
 
     def get_output_transformer(self, vial):
         """Get the output transformer for a given vial."""
-        return self.output_transformer.setdefault(vial, copy(self.default_output_transformer))
+        return self.output_transformer.setdefault(int(vial), copy(self.default_output_transformer))

--- a/evolver/calibration/interface.py
+++ b/evolver/calibration/interface.py
@@ -238,8 +238,10 @@ class IndependentVialBasedCalibrator(Calibrator, ABC):
 
     def get_input_transformer(self, vial):
         """Get the input transformer for a given vial."""
+        self.input_transformer = {} if self.input_transformer is None else self.input_transformer
         return self.input_transformer.setdefault(int(vial), copy(self.default_input_transformer))
 
     def get_output_transformer(self, vial):
         """Get the output transformer for a given vial."""
+        self.output_transformer = {} if self.output_transformer is None else self.output_transformer
         return self.output_transformer.setdefault(int(vial), copy(self.default_output_transformer))

--- a/evolver/calibration/standard/actions/temperature.py
+++ b/evolver/calibration/standard/actions/temperature.py
@@ -47,4 +47,5 @@ class CalculateFitAction(CalibrationAction):
     def execute(self, state: CalibrationStateModel, payload: Optional[FormModel] = None):
         vial_data = state.measured[self.vial_idx]
         self.hardware.calibrator.output_transformer[self.vial_idx].refit(vial_data["reference"], vial_data["raw"])
+        state.fitted_calibrator = self.hardware.calibrator.descriptor
         return state

--- a/evolver/calibration/standard/calibrators/temperature.py
+++ b/evolver/calibration/standard/calibrators/temperature.py
@@ -14,6 +14,10 @@ class TemperatureCalibrator(IndependentVialBasedCalibrator):
     A calibrator for each vial's temperature sensor.
     """
 
+    def init_transformers(self, calibration_data: CalibrationStateModel):
+        for vial, data in calibration_data.measured.items():
+            self.get_output_transformer(vial).refit(data["reference"], data["raw"])
+
     def create_calibration_procedure(
         self,
         selected_hardware: HardwareDriver,

--- a/evolver/hardware/standard/tests/test_temperature_calibrator.py
+++ b/evolver/hardware/standard/tests/test_temperature_calibrator.py
@@ -1,0 +1,26 @@
+import pytest
+
+from evolver.calibration.demo import NoOpTransformer
+from evolver.calibration.interface import CalibrationStateModel
+from evolver.calibration.standard.calibrators.temperature import TemperatureCalibrator
+
+
+@pytest.fixture
+def temperature_calibration_file(tmp_path):
+    measured = {
+        "0": {"reference": 0, "raw": 1},
+        "1": {"reference": 99, "raw": 100},
+    }
+    CalibrationStateModel(measured=measured).save(tmp_path / "temperature_calibration_file.yaml")
+    return tmp_path / "temperature_calibration_file.yaml"
+
+
+def test_temperature_initialization_refit(temperature_calibration_file):
+    calibrator = TemperatureCalibrator(
+        calibration_file=temperature_calibration_file,
+        default_output_transformer=NoOpTransformer(param1=1.0),
+    )
+    # we expect the measured raw and reference to be passed to the refit method
+    # of transformers as (reference, raw) tuple args.
+    assert calibrator.get_output_transformer(0)._refit_args == (0, 1)
+    assert calibrator.get_output_transformer(1)._refit_args == (99, 100)

--- a/evolver/tests/test_calibrator.py
+++ b/evolver/tests/test_calibrator.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
 from evolver.calibration.demo import NoOpCalibrator, NoOpTransformer
-from evolver.calibration.interface import CalibrationStateModel, Status
+from evolver.calibration.interface import CalibrationStateModel, IndependentVialBasedCalibrator, Status
 from evolver.hardware.demo import NoOpSensorDriver
 from evolver.settings import settings
 
@@ -85,3 +85,19 @@ class TestCalibrator:
         # same as above, but set the no_refit flag
         new_calibrator = NoOpCalibrator(calibration_file=cal_file, no_refit=True)
         assert new_calibrator.output_transformer.param1 == calibrator.output_transformer.param1
+
+    def test_default_transformer(self):
+        class TestCalibrator(IndependentVialBasedCalibrator):
+            def create_calibration_procedure(self, *args, **kwargs):
+                pass
+
+        obj = TestCalibrator(
+            default_input_transformer=NoOpTransformer(param1=1.0),
+            input_transformer={
+                0: NoOpTransformer(param1=2.0),
+            },
+        )
+        assert obj.get_input_transformer("0").param1 == 2.0
+        assert obj.get_input_transformer(0).param1 == 2.0
+        assert obj.get_input_transformer("1").param1 == 1.0
+        assert obj.get_input_transformer(1).param1 == 1.0


### PR DESCRIPTION
This change adds:
* A place to store fitted transformers within the calibration procedure state model, enabling to use the prefit transformers without a refit (in cases where no measured data is stored, or when fitting must be done outside the system).
* A path to detect when to use fitted transformers and automatically apply
* Parameters for default transformers for the multi-vial case. This can be used in the common case where all vials use the same method (each will still be fit with their own parameters)
* Code for at-initialization refit of the temperature calibrator.

I think this resolves or otherwise closes following issues:
* #234 since we can pass via `calibration_file` property now
* #179 since we are committed to working with the files for procedure and loading
* #165 I think this is actually resolved already, but this closes the loop in how to apply from saved procedure data
* #193 we have the machinery to refit to a transformer config spec'ed without fit params