### PR TITLE
add name to healthz endpoint

### DIFF
--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -174,7 +174,11 @@ async def post_event(info: EventInfo):
 
 @app.get("/healthz", operation_id="healthcheck")
 async def healthz():
-    return {"message": f"Running '{__project__}' ver: '{__version__}'", "active": app.state.evolver.enable_control}
+    return {
+        "message": f"Running '{__project__}' ver: '{__version__}'",
+        "active": app.state.evolver.enable_control,
+        "name": app.state.evolver.name,
+    }
 
 
 async def evolver_async_loop():

--- a/evolver/app/tests/test_app.py
+++ b/evolver/app/tests/test_app.py
@@ -37,6 +37,7 @@ class TestApp:
         assert response.status_code == 200
         if __version__:
             assert __version__ in response.json()["message"], response.json()
+        assert response.json()["name"]
         assert response.json()["active"]
 
     def test_evolver_app_default_config_dump_endpoint(self, app_client):


### PR DESCRIPTION
adds the evolver name to the healthz response. This is so the frontend can use a human-readable name for the device as it exists in the frontend database.