### PR TITLE
update to hardware effector set method

### DIFF
--- a/evolver/hardware/interface.py
+++ b/evolver/hardware/interface.py
@@ -78,6 +78,17 @@ class EffectorDriver(VialHardwareDriver):
         self.proposal: dict[int, self.Input] = {}
         self.committed: dict[int, self.Input] = {}
 
+    def _get_input_from_args(self, *args, **kwargs):
+        if kwargs and args:
+            raise ValueError("Pass either an input model instance or input fields to set")
+        if args:
+            input = args[0]
+        elif kwargs:
+            input = kwargs
+        else:
+            raise ValueError("No input provided")
+        return self.Input.model_validate(input)
+
     def set(self, *args, **kwargs):
         """Set a value proposal for the hardware.
 
@@ -92,15 +103,7 @@ class EffectorDriver(VialHardwareDriver):
         communicating with the underlying hardware is handled in the commit
         method.
         """
-        if kwargs and args:
-            raise ValueError("Pass either an input model instance or input fields to set")
-        if args:
-            input = args[0]
-        elif kwargs:
-            input = kwargs
-        else:
-            raise ValueError("No input provided")
-        validated_input = self.Input.model_validate(input)
+        validated_input = self._get_input_from_args(*args, **kwargs)
         self.proposal[validated_input.vial] = validated_input
 
     @abstractmethod

--- a/evolver/tests/test_hardware_interface.py
+++ b/evolver/tests/test_hardware_interface.py
@@ -1,0 +1,36 @@
+import pytest
+
+from evolver.hardware.interface import EffectorDriver
+
+
+def test_effector_driver_set():
+    class TestEffectorDriver(EffectorDriver):
+        class Input(EffectorDriver.Input):
+            value_a: float
+            value_b: float = 0.0
+
+        def commit(self):
+            pass
+
+        def off(self):
+            pass
+
+    driver = TestEffectorDriver()
+    driver.set(vial=0, value_a=1.0)
+    assert driver.proposal == {0: TestEffectorDriver.Input(vial=0, value_a=1.0)}
+
+    driver = TestEffectorDriver()
+    with pytest.raises(ValueError):  # needs vial
+        driver.set(value_a=1.0, value_b=2.0)
+
+    driver = TestEffectorDriver()
+    driver.set(TestEffectorDriver.Input(vial=0, value_a=1.0))
+    assert driver.proposal == {0: TestEffectorDriver.Input(vial=0, value_a=1.0)}
+
+    driver = TestEffectorDriver()
+    with pytest.raises(ValueError):  # shouldn't be allowed to mix
+        driver.set(TestEffectorDriver.Input(vial=0, value_a=1.0), vial=0, value_a=1, value_b=2.0)
+
+    driver = TestEffectorDriver()
+    with pytest.raises(ValueError):  # needs input
+        driver.set()


### PR DESCRIPTION
I noticed this for a while but was reminded again when working with the pump driver. In some cases we might be working with the model when setting values to hardware, but in other case removing the need to explicitly construct the model is more natural. This enables both:

```py
model = Driver.Input(vial=0, value=1)
hardware.set(model)
```

or 
```py
hardware.set(vial=0, value=1)
```

With this change, these are equivalent (assuming hardware is instance of `Driver`) and both go through model validation.

Comes with some updated doc strings as well