### PR TITLE
Pump calibration procedure

### DIFF
--- a/evolver/calibration/procedure.py
+++ b/evolver/calibration/procedure.py
@@ -44,9 +44,21 @@ class CalibrationProcedure(BaseInterface, ABC):
                 f"If you want to repeat an action, any action can be dispatched multiple times using the HTTP api."
             )
         self.actions.append(action)
+        return self
+
+    def add_action_list(self, actions: list[CalibrationAction]):
+        for action in actions:
+            self.add_action(action)
+        return self
 
     def get_actions(self):
         return self.actions
+
+    def get_action(self, name):
+        actions = [action for action in self.actions if action.name == name]
+        if len(actions) == 0:
+            raise ValueError(f"Action with name '{name}' not found.")
+        return actions[0]
 
     def get_state(self, *args, **kwargs):
         return self.state
@@ -101,7 +113,9 @@ class CalibrationProcedure(BaseInterface, ABC):
 
         return self.state
 
-    def dispatch(self, action: CalibrationAction, payload: Dict[str, Any]):
+    def dispatch(self, action: CalibrationAction | str, payload: Dict[str, Any]):
+        if isinstance(action, str):
+            action = self.get_action(action)
         if payload is not None and action.FormModel.model_fields != {}:
             payload = action.FormModel(**payload)
         previous_state = self.state.model_dump()

--- a/evolver/calibration/procedure.py
+++ b/evolver/calibration/procedure.py
@@ -107,7 +107,7 @@ class CalibrationProcedure(BaseInterface, ABC):
 
         return self.state
 
-    def dispatch(self, action: CalibrationAction | str, payload: Dict[str, Any]):
+    def dispatch(self, action: CalibrationAction, payload: Dict[str, Any]):
         if payload is not None and action.FormModel.model_fields != {}:
             payload = action.FormModel(**payload)
         previous_state = self.state.model_dump()

--- a/evolver/calibration/procedure.py
+++ b/evolver/calibration/procedure.py
@@ -44,12 +44,6 @@ class CalibrationProcedure(BaseInterface, ABC):
                 f"If you want to repeat an action, any action can be dispatched multiple times using the HTTP api."
             )
         self.actions.append(action)
-        return self
-
-    def add_action_list(self, actions: list[CalibrationAction]):
-        for action in actions:
-            self.add_action(action)
-        return self
 
     def get_actions(self):
         return self.actions
@@ -114,8 +108,6 @@ class CalibrationProcedure(BaseInterface, ABC):
         return self.state
 
     def dispatch(self, action: CalibrationAction | str, payload: Dict[str, Any]):
-        if isinstance(action, str):
-            action = self.get_action(action)
         if payload is not None and action.FormModel.model_fields != {}:
             payload = action.FormModel(**payload)
         previous_state = self.state.model_dump()

--- a/evolver/calibration/standard/calibrators/pump.py
+++ b/evolver/calibration/standard/calibrators/pump.py
@@ -1,0 +1,115 @@
+from pydantic import BaseModel, Field
+
+from evolver.calibration.action import CalibrationAction, DisplayInstructionAction
+from evolver.calibration.interface import CalibrationStateModel, IndependentVialBasedCalibrator, Transformer
+from evolver.calibration.procedure import CalibrationProcedure
+
+
+class RateTransformer(Transformer):
+    class Config(Transformer.Config):
+        rate: float
+
+    def convert_to(self, time):  # convert to volume from time
+        return self.rate * time
+
+    def convert_from(self, volume):  # convert to time from volume
+        return volume / self.rate
+
+
+class PumpAction(CalibrationAction):
+    """Run the pump for the configured time.
+
+    The action takes as input a flag for running in fast mode, the times of
+    which are configured in the constructor fast/slow args (in seconds).
+    """
+
+    def __init__(self, *args, fast, slow, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.pump_speeds = (slow, fast)
+
+    class FormModel(BaseModel):
+        use_fast_mode: bool = Field(False, description="Use fast mode for calibration?")
+
+    def execute(self, state, payload):
+        state.time_pumped = self.pump_speeds[payload.use_fast_mode]
+        for pump_id in self.hardware.pump_ids:
+            self.hardware.set(pump_id=pump_id, time=state.time_pumped)
+        self.hardware.commit()
+        return state
+
+
+class RecordVolumeAction(CalibrationAction):
+    """Record volume pumped in mL for a given pump."""
+
+    class FormModel(BaseModel):
+        volume: float = Field(description="Volume pumped in mL")
+
+    def __init__(self, *args, pump_id, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.pump_id = pump_id
+
+    def execute(self, state, payload):
+        state.measured[self.pump_id] = (state.time_pumped, payload.volume)
+        return state
+
+
+class GenericPumpCalibrator(IndependentVialBasedCalibrator):
+    class Config(IndependentVialBasedCalibrator.Config):
+        time_to_pump_fast: float = 10.0
+        time_to_pump_slow: float = 100.0
+
+    def init_transformers(self, calibration_data):
+        self.input_transformer = {}
+        for vial, (time, volume) in calibration_data.measured.items():
+            self.input_transformer[vial] = RateTransformer(rate=volume / time)
+
+    def create_calibration_procedure(self, selected_hardware, resume, *args, **kwargs):
+        procedure_state = CalibrationStateModel.load(self.procedure_file) if resume else None
+
+        self.calibration_procedure = (
+            CalibrationProcedure(
+                state=procedure_state.model_dump() if procedure_state else None, hardware=selected_hardware
+            )
+            .add_action(
+                DisplayInstructionAction(
+                    description="Fill a large beaker with water. Submerge pump lines ensuring ends are below the surface",
+                    name="fill_beaker",
+                    hardware=selected_hardware,
+                )
+            )
+            .add_action(
+                DisplayInstructionAction(
+                    description=(
+                        "For each pump, set a vial in a rack and place line in vial. Note that to prevent damage"
+                        "from overrun, vials should not be placed on the evolver in this procedure"
+                    ),
+                    name="place_vials",
+                    hardware=selected_hardware,
+                )
+            )
+            .add_action(
+                PumpAction(
+                    fast=self.time_to_pump_fast,
+                    slow=self.time_to_pump_slow,
+                    name="pump_run",
+                    description="Run pumps",
+                    hardware=selected_hardware,
+                )
+            )
+            .add_action(
+                DisplayInstructionAction(
+                    description="Wait for pumps to finish", name="wait_pumps", hardware=selected_hardware
+                )
+            )
+            .add_action_list(
+                [
+                    RecordVolumeAction(
+                        name=f"record_pump_{pump_id}",
+                        description=f"Record volume for pump {pump_id}",
+                        hardware=selected_hardware,
+                        pump_id=pump_id,
+                    )
+                    for pump_id in selected_hardware.pump_ids
+                ]
+            )
+        )

--- a/evolver/hardware/standard/pump.py
+++ b/evolver/hardware/standard/pump.py
@@ -42,7 +42,7 @@ class GenericPump(EffectorDriver):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.pump_ids = self.active_pumps if self.active_pumps else list(range(self.slots))
+        self.pump_ids = list(range(self.slots)) if self.active_pumps is None else self.active_pumps
         if self.ipp_pumps is True:
             self.ipp_pumps = list(range(self.slots / 3))
         elif self.ipp_pumps in (False, None):
@@ -53,10 +53,12 @@ class GenericPump(EffectorDriver):
         return self.serial_conn or self.evolver.serial
 
     def set(self, *args, **kwargs):
-        # We index here by pump_id, which is a concept outside of vail - we
+        # We index here by pump_id, which is a concept outside of vial - we
         # don't want confuse things by overloading the concept, so be explicit
         # here
         input = self._get_input_from_args(*args, **kwargs)
+        if input.pump_id not in self.pump_ids:
+            raise ValueError(f"pump_id {input.pump_id} not in active pumps")
         self.proposal[input.pump_id] = input
 
     def commit(self):

--- a/evolver/hardware/standard/pump.py
+++ b/evolver/hardware/standard/pump.py
@@ -1,37 +1,13 @@
 from copy import copy
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from evolver.base import BaseConfig, ConfigDescriptor
-from evolver.calibration.interface import Calibrator, IndependentVialBasedCalibrator, Transformer
+from evolver.calibration.interface import Calibrator
+from evolver.calibration.standard.calibrators.pump import GenericPumpCalibrator
 from evolver.hardware.interface import EffectorDriver
 from evolver.hardware.standard.base import SerialDeviceConfigBase
 from evolver.serial import SerialData
-
-
-class RateTransformer(Transformer):
-    class Config(Transformer.Config):
-        rate: float
-
-    def convert_to(self, time):  # convert to volume from time
-        return self.rate * time
-
-    def convert_from(self, volume):  # convert to time from volume
-        return volume / self.rate
-
-
-class GenericPumpCalibrator(IndependentVialBasedCalibrator):
-    class Config(IndependentVialBasedCalibrator.Config):
-        time_to_pump_fast: float = 10.0
-        time_to_pump_slow: float = 100.0
-
-    def init_transformers(self, calibration_data):
-        self.input_transformer = {}
-        for vial, (time, volume) in calibration_data.measured.items():
-            self.input_transformer[vial] = RateTransformer(rate=volume / time)
-
-    def create_calibration_procedure(self, selected_hardware, resume, *args, **kwargs):
-        raise NotImplementedError
 
 
 class GenericPump(EffectorDriver):
@@ -50,14 +26,23 @@ class GenericPump(EffectorDriver):
     class Config(SerialDeviceConfigBase, EffectorDriver.Config):
         ipp_pumps: bool | list[int] = Field(False, description="False (no IPP), True (all IPP), or list of IPP ids")
         calibrator: ConfigDescriptor | Calibrator = ConfigDescriptor(classinfo=GenericPumpCalibrator)
+        active_pumps: list[int] | None = Field(None, description="List of active pump IDs, or None for all")
 
     class Input(BaseConfig):  # This intentionally doesn't inherit from EffectorDriver.Input.
         pump_id: int
-        volume: float = Field(description="Volume to pump in mL per event")
+        volume: float = Field(0, description="Volume to pump in mL per event")
         rate: float = Field(0, description="Rate of pumping in volumes per hour")
+        time: float = Field(0, description="Time to pump in seconds, mutually exclusive with volume")
+
+        @model_validator(mode="after")
+        def validate(self):
+            if self.volume and self.time:
+                raise ValueError("Only one of volume or time can be specified")
+            return self
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.pump_ids = self.active_pumps if self.active_pumps else list(range(self.slots))
         if self.ipp_pumps is True:
             self.ipp_pumps = list(range(self.slots / 3))
         elif self.ipp_pumps in (False, None):
@@ -67,7 +52,11 @@ class GenericPump(EffectorDriver):
     def serial(self):
         return self.serial_conn or self.evolver.serial
 
-    def set(self, input):
+    def set(self, *args, **kwargs):
+        # We index here by pump_id, which is a concept outside of vail - we
+        # don't want confuse things by overloading the concept, so be explicit
+        # here
+        input = self._get_input_from_args(*args, **kwargs)
         self.proposal[input.pump_id] = input
 
     def commit(self):
@@ -85,7 +74,10 @@ class GenericPump(EffectorDriver):
             elif any(pump - i < 3 for i in self.ipp_pumps):
                 raise ValueError(f"pump slot {pump} reserved for IPP pump, cannot address as standard")
             else:
-                time_to_pump = self._transform("input_transformer", "convert_from", input.volume, pump)
+                if input.time:
+                    time_to_pump = input.time
+                else:
+                    time_to_pump = self._transform("input_transformer", "convert_from", input.volume, pump)
                 pump_interval = int(3600 / input.rate) if input.rate else 0
                 cmd[pump] = f"{time_to_pump}|{pump_interval}".encode()
         with self.serial as comm:

--- a/evolver/hardware/standard/tests/test_pump_calibrator.py
+++ b/evolver/hardware/standard/tests/test_pump_calibrator.py
@@ -1,7 +1,11 @@
+from unittest.mock import MagicMock
+
 import pytest
 
 from evolver.calibration.interface import CalibrationStateModel
-from evolver.hardware.standard.pump import GenericPumpCalibrator
+from evolver.calibration.standard.calibrators.pump import GenericPumpCalibrator
+from evolver.hardware.standard.pump import GenericPump
+from evolver.serial import SerialData
 from evolver.settings import settings
 
 
@@ -26,3 +30,38 @@ def test_pump_calibrator_read_from_file(cal_data):
     cal_data.save("test_cal_data.yaml")
     calibrator = GenericPumpCalibrator(calibration_file="test_cal_data.yaml")
     assert calibrator.calibration_data == cal_data
+
+
+@pytest.mark.parametrize("active_pumps", [None, [0, 2]])
+def test_pump_calibration_procedure(active_pumps):
+    calibrator = GenericPumpCalibrator()
+    hardware = GenericPump(addr="pump", calibrator=calibrator, active_pumps=active_pumps)
+    hardware.calibrator.create_calibration_procedure(selected_hardware=hardware, resume=False)
+    procedure = hardware.calibrator.calibration_procedure
+
+    procedure.dispatch("fill_beaker", {})
+    procedure.dispatch("place_vials", {})
+
+    hardware.serial_conn = MagicMock()
+    procedure.dispatch("pump_run", {})
+    # We expect the pump run to have sent the command with by default the slow
+    # pump rate set on calibrator. For those pumps not active we expect the null
+    # command (--) to be set for the relevant slot.
+    per_pump_bytes = f"{calibrator.time_to_pump_slow}|0".encode()
+    expected_cmd = SerialData(addr="pump", data=[per_pump_bytes] * hardware.slots)
+    if active_pumps:
+        for i in range(hardware.slots):
+            if i not in active_pumps:
+                expected_cmd.data[i] = b"--"
+    hardware.serial_conn.__enter__().communicate.assert_called_with(expected_cmd)
+
+    procedure.dispatch("wait_pumps", {})
+
+    measured = 2.0
+    procedure.dispatch("record_pump_0", {"volume": measured})
+    assert procedure.state.measured == ({0: (calibrator.time_to_pump_slow, measured)})
+
+    procedure.dispatch("pump_run", {"use_fast_mode": True})
+    measured = 4.0
+    procedure.dispatch("record_pump_2", {"volume": measured})
+    assert procedure.state.measured[2] == (calibrator.time_to_pump_fast, measured)

--- a/evolver/tests/test_logging.py
+++ b/evolver/tests/test_logging.py
@@ -20,7 +20,11 @@ def test_log_capture_handler():
     assert hist.kind == "log"
 
 
-def test_log_evolver_hookup():
+def test_log_evolver_hookup(caplog):
+    # to prevent pytest from taking the records before they hit our handlers, we
+    # need to set this higher than the level we are testing for below.
+    caplog.set_level(logging.CRITICAL + 1)
+
     history = InMemoryHistoryServer()
 
     class HW(SensorDriver):


### PR DESCRIPTION
This PR adds a procedure to the generic pump calibrator, while resolving some minor issues related to the pump necessary for calibration (e.g. setting `time` directly) and adding some conveniences around creating the procedure.

Specifically:
* Lift-and-shift the generic pump calibrator to a module under `standard/calibrators`
* Add the pump calibration procedure, with custom actions
* Update pump input model to take `time` (when `volume` not given)
* Add spec for active pumps on driver (slots refers to total address space, active refers to ones used)
* ~Return `self` in procedure `add_action` enabling operation chaining for readability~
* ~Add `add_action_list` method to procedure, enabling adding list in single chained call~
* Add method for getting an action by name (`get_action(self, name)`)