### PR TITLE
allow null config in yml

### DIFF
--- a/evolver/base.py
+++ b/evolver/base.py
@@ -155,7 +155,7 @@ class BaseConfig(_BaseConfig):
 
 class ConfigDescriptor(_BaseModel):
     classinfo: ImportString
-    config: dict = {}
+    config: dict | None = {}
 
     @pydantic.field_validator("classinfo", mode="after")
     @classmethod


### PR DESCRIPTION
allows nullable configs, per Ezira's requirement, fix made with input and discussion with @jamienoss.

It's a bit of an oddball in that Pydantic's syntax is a little confusing, like surely the state before the fix "means" in spirit what this fix is now explicitly stating... either that or we're not useing Pydantic optional & defaults correctly.

e.g. 

```
hardware:
  test:
    classinfo: evolver.hardware.demo.NoOpSensorDriver
    config:
      calibrator:
        classinfo: evolver.calibration.standard.calibrators.temperature.TemperatureCalibrator
        config: null
```

refs:

https://github.com/ssec-jhu/evolver-ng/issues/247
https://github.com/ssec-jhu/evolver-ng/pull/246
https://github.com/ssec-jhu/evolver-ng/issues/213
https://github.com/ssec-jhu/evolver-ng/pull/216

^ Evidently there is a more gnarly issue at play here, but this addresses the requirement.
