### PR TITLE
save the calibration procedure (and procedure_file) at the moment it …

### DIFF
--- a/evolver/app/routers/hardware.py
+++ b/evolver/app/routers/hardware.py
@@ -113,6 +113,8 @@ def start_calibration_procedure(
         resume=False,
     )
 
+    calibrator.calibration_procedure.save()
+
     return calibrator.calibration_procedure.get_state()
 
 


### PR DESCRIPTION
fixes bug where user starts procedure, (never saves it). A procedure_file exists on the config, but it doesn't exist on fs. meaning it's impossible to resume. 
