### PR TITLE
fix two bugs in temperature calibration

### DIFF
--- a/evolver/calibration/standard/actions/temperature.py
+++ b/evolver/calibration/standard/actions/temperature.py
@@ -30,7 +30,7 @@ class RawValueAction(CalibrationAction):
         self.vial_idx = vial_idx
 
     def execute(self, state: CalibrationStateModel, payload: Optional[FormModel] = None):
-        sensor_value = self.hardware.read()[self.vial_idx]
+        sensor_value = self.hardware.read()[self.vial_idx].raw
         state.measured = state.measured or defaultdict(lambda: {"reference": [], "raw": []})
         state.measured[self.vial_idx]["raw"].append(sensor_value)
         return state

--- a/evolver/hardware/standard/tests/test_temperature_calibrator.py
+++ b/evolver/hardware/standard/tests/test_temperature_calibrator.py
@@ -22,5 +22,5 @@ def test_temperature_initialization_refit(temperature_calibration_file):
     )
     # we expect the measured raw and reference to be passed to the refit method
     # of transformers as (reference, raw) tuple args.
-    assert calibrator.get_output_transformer(0)._refit_args == (0, 1)
-    assert calibrator.get_output_transformer(1)._refit_args == (99, 100)
+    assert calibrator.get_output_transformer(0)._refit_args == (1, 0)
+    assert calibrator.get_output_transformer(1)._refit_args == (100, 99)


### PR DESCRIPTION
Two bugs:

* the sensor read action was writing out a struct of the form of `Temperature.Output`, but we really just want the `raw` value from that struct. Corresponding test updated reflecting this
* The "sense" of the fit was backwards, we have advised that convert_to be used in output_transformer for raw to real, but the fit was backwards for this case

Sneaking in also a config to set default output transformer on the temp calibrator to linear fit