### PR TITLE
Add set temperature action to calibration waves

### DIFF
--- a/evolver/calibration/standard/actions/temperature.py
+++ b/evolver/calibration/standard/actions/temperature.py
@@ -46,11 +46,11 @@ class AdjustHeaterAction(CalibrationAction):
         self.raw_adjustment = raw_adjustment
 
     def execute(self, state: CalibrationStateModel, payload=None):
-        current_readings = self.hardware.get()
         for vial in self.vials:
-            # current readings could come average of historical readings using
-            # history server.
-            raw = int(current_readings[vial].raw + self.raw_adjustment)
+            # To do the adjustment action, we have to have read the room temp
+            # reading, and it has to have been the first reading measured.
+            room_temp_raw = state.measured[vial]["raw"][0]
+            raw = int(room_temp_raw + self.raw_adjustment)
             self.hardware.set(vial=vial, temperature=None, raw=raw)
         self.hardware.commit()
         return state

--- a/evolver/calibration/standard/actions/temperature.py
+++ b/evolver/calibration/standard/actions/temperature.py
@@ -39,6 +39,35 @@ class RawValueAction(CalibrationAction):
         return state
 
 
+class AdjustHeaterAction(CalibrationAction):
+    def __init__(self, vials: list[int], raw_adjustment: int, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.vials = vials
+        self.raw_adjustment = raw_adjustment
+
+    def execute(self, state: CalibrationStateModel, payload=None):
+        current_readings = self.hardware.get()
+        for vial in self.vials:
+            # current readings could come average of historical readings using
+            # history server.
+            raw = int(current_readings[vial].raw + self.raw_adjustment)
+            self.hardware.set(vial=vial, temperature=None, raw=raw)
+        self.hardware.commit()
+        return state
+
+
+class HeaterOffAction(CalibrationAction):
+    def __init__(self, vials: list[int], *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.vials = vials
+
+    def execute(self, state: CalibrationStateModel, payload=None):
+        for vial in self.vials:
+            self.hardware.set(vial=vial, temperature=None, raw=None)
+        self.hardware.commit()
+        return state
+
+
 class CalculateFitAction(CalibrationAction):
     class FormModel(BaseModel):
         pass

--- a/evolver/calibration/standard/actions/temperature.py
+++ b/evolver/calibration/standard/actions/temperature.py
@@ -39,7 +39,7 @@ class RawValueAction(CalibrationAction):
         return state
 
 
-class AdjustHeaterAction(CalibrationAction):
+class AllVialsAdjustHeaterAction(CalibrationAction):
     def __init__(self, vials: list[int], raw_adjustment: int, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.vials = vials
@@ -47,16 +47,13 @@ class AdjustHeaterAction(CalibrationAction):
 
     def execute(self, state: CalibrationStateModel, payload=None):
         for vial in self.vials:
-            # To do the adjustment action, we have to have read the room temp
-            # reading, and it has to have been the first reading measured.
-            room_temp_raw = state.measured[vial]["raw"][0]
-            raw = int(room_temp_raw + self.raw_adjustment)
+            raw = int(state.roomTempRawValues[vial] + self.raw_adjustment)
             self.hardware.set(vial=vial, temperature=None, raw=raw)
         self.hardware.commit()
         return state
 
 
-class HeaterOffAction(CalibrationAction):
+class AllVialsHeaterOffAction(CalibrationAction):
     def __init__(self, vials: list[int], *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.vials = vials
@@ -65,6 +62,20 @@ class HeaterOffAction(CalibrationAction):
         for vial in self.vials:
             self.hardware.set(vial=vial, temperature=None, raw=None)
         self.hardware.commit()
+        return state
+
+
+class AllVialsReadRoomTempAction(CalibrationAction):
+    def __init__(self, vials: list[int], num_readings=3, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.vials = vials
+        self.num_readings = num_readings
+
+    def execute(self, state: CalibrationStateModel, payload=None):
+        readings = [self.hardware.read() for _ in range(self.num_readings)]
+        # unpack the readings into per-vial set of raw values
+        per_vial_raw = {vial: [readings[i][vial].raw for i in range(self.num_readings)] for vial in self.vials}
+        state.roomTempRawValues = {vial: int(np.median(per_vial_raw[vial])) for vial in self.vials}
         return state
 
 

--- a/evolver/calibration/standard/calibrators/temperature.py
+++ b/evolver/calibration/standard/calibrators/temperature.py
@@ -71,8 +71,10 @@ class TemperatureCalibrator(IndependentVialBasedCalibrator):
             else:
                 # We adjust heaters relative to room temperature evenly in the
                 # configured range per step.
-                adjustment = -1 * (self.heater_boundary_high - self.heater_boundary_low) / (self.num_temp_readings - 1)
-                approx_delta = -1 * i * self.heater_slope_init * adjustment  # This is just for display purposes
+                adjustment = (
+                    -1 * i * (self.heater_boundary_high - self.heater_boundary_low) / (self.num_temp_readings - 1)
+                )
+                approx_delta = -1 * self.heater_slope_init * adjustment  # This is just for display purposes
                 calibration_procedure.add_action(
                     AdjustHeaterAction(
                         name=f"vial_sweep_{i}_adjust_heaters",

--- a/evolver/calibration/standard/calibrators/temperature.py
+++ b/evolver/calibration/standard/calibrators/temperature.py
@@ -84,7 +84,7 @@ class TemperatureCalibrator(IndependentVialBasedCalibrator):
                         vials=self.vials,
                         raw_adjustment=adjustment,
                         description=(
-                            f"Begin sweep for temperature wave {i + 1}/{self.num_temp_readings}."
+                            f"Begin sweep for temperature wave {i + 1}/{self.num_temp_readings}. "
                             f"Will set heaters to approximately room temp +{approx_delta:0.2f} C"
                         ),
                         hardware=selected_hardware,
@@ -104,7 +104,7 @@ class TemperatureCalibrator(IndependentVialBasedCalibrator):
                     AllVialsReadRoomTempAction(
                         name="vial_sweep_0_read_room_temp",
                         vials=self.vials,
-                        description="The hardware will now read the raw output values of the room temperature sensor.",
+                        description="The hardware will now read and store the raw outputs of each vial sensor.",
                         hardware=selected_hardware,
                     )
                 )

--- a/evolver/hardware/standard/temperature.py
+++ b/evolver/hardware/standard/temperature.py
@@ -36,7 +36,7 @@ class Temperature(SensorDriver, EffectorDriver):
 
     class Input(EffectorDriver.Input):
         temperature: float | None = Field(None, description="Target temperature in degrees Celsius")
-        raw: int = Field(4095, description="Raw value to set the heater to")
+        raw: int = Field(4095, description="Raw value to set the heater to. Only used if temperature is not set")
 
     @property
     def serial(self):

--- a/evolver/hardware/standard/temperature.py
+++ b/evolver/hardware/standard/temperature.py
@@ -23,8 +23,8 @@ class Temperature(SensorDriver, EffectorDriver):
     stands in for off (HEAT_OFF property of this class).
     """
 
-    HEAT_OFF_RAW = 4095
-    HEAT_OFF = str(HEAT_OFF_RAW).encode()
+    HEAT_OFF_RAW = 4095  # Raw value for heater off for input data structure
+    HEAT_OFF_CMD = str(HEAT_OFF_RAW).encode()  # Serial command for above (to reduce boilerplate)
 
     class Config(SerialDeviceConfigBase, EffectorDriver.Config):
         calibrator: Calibrator | None = FieldInfo.merge_field_infos(
@@ -36,6 +36,12 @@ class Temperature(SensorDriver, EffectorDriver):
         temperature: float | None = Field(None, description="Sensor temperature in degrees Celsius")
 
     class Input(EffectorDriver.Input):
+        """Input for heater control.
+
+        raw will be used when temperature is not set. If neither is set, the heater
+        will be turned off.
+        """
+
         temperature: float | None = Field(None, description="Target temperature in degrees Celsius")
         raw: int | None = Field(None, description="Raw value to set the heater to. Only used if temperature is not set")
 
@@ -44,7 +50,7 @@ class Temperature(SensorDriver, EffectorDriver):
         return self.serial_conn or self.evolver.serial
 
     def _do_serial(self, from_proposal=False):
-        data = [self.HEAT_OFF] * self.slots
+        data = [self.HEAT_OFF_CMD] * self.slots
         # since a read is also a send, we load all committed values as a base and
         # in the case of proposals overwrite with new data.
         inputs = copy(self.committed)
@@ -77,6 +83,6 @@ class Temperature(SensorDriver, EffectorDriver):
         self._do_serial(from_proposal=True)
 
     def off(self):
-        cmd = [self.HEAT_OFF] * self.slots
+        cmd = [self.HEAT_OFF_CMD] * self.slots
         with self.serial as comm:
             comm.communicate(SerialData(addr=self.addr, data=cmd))

--- a/evolver/hardware/standard/temperature.py
+++ b/evolver/hardware/standard/temperature.py
@@ -23,7 +23,8 @@ class Temperature(SensorDriver, EffectorDriver):
     stands in for off (HEAT_OFF property of this class).
     """
 
-    HEAT_OFF = b"4095"
+    HEAT_OFF_RAW = 4095
+    HEAT_OFF = str(HEAT_OFF_RAW).encode()
 
     class Config(SerialDeviceConfigBase, EffectorDriver.Config):
         calibrator: Calibrator | None = FieldInfo.merge_field_infos(
@@ -36,7 +37,7 @@ class Temperature(SensorDriver, EffectorDriver):
 
     class Input(EffectorDriver.Input):
         temperature: float | None = Field(None, description="Target temperature in degrees Celsius")
-        raw: int = Field(4095, description="Raw value to set the heater to. Only used if temperature is not set")
+        raw: int | None = Field(None, description="Raw value to set the heater to. Only used if temperature is not set")
 
     @property
     def serial(self):
@@ -52,7 +53,7 @@ class Temperature(SensorDriver, EffectorDriver):
         for vial, input in inputs.items():
             # Calibrate temperature to raw data.
             if input.temperature is None:
-                raw = input.raw
+                raw = input.raw if input.raw is not None else self.HEAT_OFF_RAW
             else:
                 raw = int(self._transform("input_transformer", "convert_from", input.temperature, vial))
             data[vial] = str(raw).encode()

--- a/evolver/hardware/standard/tests/test_standard.py
+++ b/evolver/hardware/standard/tests/test_standard.py
@@ -80,6 +80,7 @@ class TestTempSensor:
             [[Temperature.Input(vial=0, temperature=30.1), Temperature.Input(vial=1, temperature=40.5)], []],
             [b"tempr,4095,1523,_!", b"tempr,4095,1523,_!"],
         ),
+        ({"addr": "temp", "vials": [0], "slots": 2}, [[Temperature.Input(vial=0)], []], [b"tempr,4095,4095,_!", b"tempr,4095,4095,_!"]),
     ],
 )
 class TestTempEffectorMode(SerialVialEffectorHardwareTestSuite):

--- a/evolver/hardware/standard/tests/test_standard.py
+++ b/evolver/hardware/standard/tests/test_standard.py
@@ -81,7 +81,7 @@ class TestTempSensor:
             [b"tempr,4095,1523,_!", b"tempr,4095,1523,_!"],
         ),
         (
-            {"addr": "temp", "vials": [0], "slots": 2},
+            {"addr": "temp", "vials": [0, 1], "slots": 2},
             [[Temperature.Input(vial=0)], [Temperature.Input(vial=1, raw=1234)]],
             [b"tempr,4095,4095,_!", b"tempr,4095,1234,_!"],
         ),

--- a/evolver/hardware/standard/tests/test_standard.py
+++ b/evolver/hardware/standard/tests/test_standard.py
@@ -80,7 +80,11 @@ class TestTempSensor:
             [[Temperature.Input(vial=0, temperature=30.1), Temperature.Input(vial=1, temperature=40.5)], []],
             [b"tempr,4095,1523,_!", b"tempr,4095,1523,_!"],
         ),
-        ({"addr": "temp", "vials": [0], "slots": 2}, [[Temperature.Input(vial=0)], []], [b"tempr,4095,4095,_!", b"tempr,4095,4095,_!"]),
+        (
+            {"addr": "temp", "vials": [0], "slots": 2},
+            [[Temperature.Input(vial=0)], []],
+            [b"tempr,4095,4095,_!", b"tempr,4095,4095,_!"],
+        ),
     ],
 )
 class TestTempEffectorMode(SerialVialEffectorHardwareTestSuite):

--- a/evolver/hardware/standard/tests/test_standard.py
+++ b/evolver/hardware/standard/tests/test_standard.py
@@ -82,8 +82,8 @@ class TestTempSensor:
         ),
         (
             {"addr": "temp", "vials": [0], "slots": 2},
-            [[Temperature.Input(vial=0)], []],
-            [b"tempr,4095,4095,_!", b"tempr,4095,4095,_!"],
+            [[Temperature.Input(vial=0)], [Temperature.Input(vial=1, raw=1234)]],
+            [b"tempr,4095,4095,_!", b"tempr,4095,1234,_!"],
         ),
     ],
 )

--- a/evolver/hardware/standard/tests/test_temperature_calibrator.py
+++ b/evolver/hardware/standard/tests/test_temperature_calibrator.py
@@ -1,4 +1,5 @@
 from unittest.mock import MagicMock
+
 import pytest
 
 from evolver.calibration.demo import NoOpTransformer
@@ -46,4 +47,3 @@ def test_temperature_calibrator_effector_actions():
     action = procedure.get_action("vial_sweep_2_adjust_heaters")
     action.execute(state=None)
     mock_hardware.set.assert_called_with(vial=0, temperature=None, raw=1000)
-

--- a/evolver/hardware/standard/tests/test_temperature_calibrator.py
+++ b/evolver/hardware/standard/tests/test_temperature_calibrator.py
@@ -38,12 +38,11 @@ def test_temperature_calibrator_effector_actions():
     action.execute(state=None)
     mock_hardware.set.assert_called_with(vial=0, temperature=None, raw=None)
     # temp 1
-    mock_hardware.get.return_value = {0: MagicMock(raw=2000)}
+    state = CalibrationStateModel(measured={0: {"raw": [2000]}})
     action = procedure.get_action("vial_sweep_1_adjust_heaters")
-    action.execute(state=None)
+    action.execute(state=state)
     mock_hardware.set.assert_called_with(vial=0, temperature=None, raw=1500)
     # temp 2
-    mock_hardware.get.return_value = {0: MagicMock(raw=1500)}
     action = procedure.get_action("vial_sweep_2_adjust_heaters")
-    action.execute(state=None)
+    action.execute(state=state)
     mock_hardware.set.assert_called_with(vial=0, temperature=None, raw=1000)

--- a/evolver/hardware/standard/tests/test_temperature_calibrator.py
+++ b/evolver/hardware/standard/tests/test_temperature_calibrator.py
@@ -37,8 +37,11 @@ def test_temperature_calibrator_effector_actions():
     action = procedure.get_action("vial_sweep_0_turn_off_heaters")
     action.execute(state=None)
     mock_hardware.set.assert_called_with(vial=0, temperature=None, raw=None)
+    # do the room temp read action
+    mock_hardware.read.return_value = {0: MagicMock(raw=2000)}
+    action = procedure.get_action("vial_sweep_0_read_room_temp")
+    state = action.execute(state=CalibrationStateModel())
     # temp 1
-    state = CalibrationStateModel(measured={0: {"raw": [2000]}})
     action = procedure.get_action("vial_sweep_1_adjust_heaters")
     action.execute(state=state)
     mock_hardware.set.assert_called_with(vial=0, temperature=None, raw=1500)


### PR DESCRIPTION
This:
* For fist wave: Turns off the heater 
* For all other waves: Sets the heater to a raw adc value proportional to number of steps within a configurable range, relative to the read-in room temperature settings (taken during the first wave). For example:
  * if raw reading taken at first wave for vial 0 is `2048`, range `(heater_boundary_low, heater_boundary_high)` is `(0, 1000)`, and `num_temp_readings` is `3`. The second wave for vial 0 will be set at `1548` and the second will be `1048`
  * For the temp sensor this corresponds to approximately +10C and +20C for three waves (sensor ~0.02C/unit)

It also fixes the temp driver to allow raw to be set in input

This was modeled after https://github.com/FYNCH-BIO/evolver-electron/blob/master/app/components/TempCalibrate.js, or at least my reading of it