### PR TITLE
run loop in thread in main application

### DIFF
--- a/evolver/app/main.py
+++ b/evolver/app/main.py
@@ -1,5 +1,5 @@
-import asyncio
 import logging
+import threading
 from contextlib import asynccontextmanager
 from http import HTTPStatus
 
@@ -33,7 +33,7 @@ async def lifespan(app: FastAPI):
         app.state.evolver = Evolver.create()
 
     with app.state.evolver:
-        asyncio.create_task(evolver_async_loop())
+        threading.Thread(target=evolver_thread_loop, daemon=True).start()
         yield
 
     # Shutdown:
@@ -42,6 +42,14 @@ async def lifespan(app: FastAPI):
 
 app = FastAPI(lifespan=lifespan, default_response_class=ORJSONResponse)
 app.state.evolver = None
+app.state.trigger = threading.Event()
+
+
+def evolver_thread_loop():
+    while True:
+        app.state.evolver.loop_once()
+        app.state.trigger.wait(timeout=app.state.evolver.interval)
+        app.state.trigger.clear()
 
 
 @require_all_fields
@@ -116,6 +124,7 @@ async def update_evolver(config: EvolverConfigWithoutDefaults):
     """
     app.state.evolver = Evolver.create(config)
     app.state.evolver.config_model.save(app_settings.CONFIG_FILE)
+    app.state.trigger.set()
 
 
 @app.get("/schema/", response_model=SchemaResponse, operation_id="schema")
@@ -179,15 +188,6 @@ async def healthz():
         "active": app.state.evolver.enable_control,
         "name": app.state.evolver.name,
     }
-
-
-async def evolver_async_loop():
-    while True:
-        try:
-            app.state.evolver.loop_once()
-        except RuntimeError:
-            logging.exception("Error in loop")
-        await asyncio.sleep(app.state.evolver.interval)
 
 
 @app.get("/calibration_status/")


### PR DESCRIPTION
Since the device manager loop activity is not itself async and has some blocking sections, we run within a thread instead of coroutine. This also implements the loop wait interval to an event with timeout in order to support on-demain re-evaluation of the loop during update.