### PR TITLE
Docs update

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -1,6 +1,15 @@
 API
 ===
 
+Configuration
+-------------
+
+.. autosummary::
+   :toctree: generated
+
+   evolver.base.ConfigDescriptor
+   evolver.base.ConfigDescriptor.create
+
 Hardware Extension Points
 -------------------------
 

--- a/docs/source/concepts.rst
+++ b/docs/source/concepts.rst
@@ -1,7 +1,7 @@
-Evolver concepts
+eVOLVER concepts
 ================
 
-The evolver system is made up of several configurable components tied together
+The eVOLVER system is made up of several configurable components tied together
 by a manager component that orchestrates the application control loop and
 exposure to the web interface. Components can be grouped into two high level
 categories:
@@ -42,7 +42,7 @@ categories:
 Configuration and ConfigDescriptors
 -----------------------------------
 
-All components in the evolver can be represented by a so-called
+All components in the eVOLVER can be represented by a so-called
 :py:class:`ConfigDescriptor<evolver.config.ConfigDescriptor>`. This is the key
 component which translates from a static serialized configuration (e.g. that
 which can be represented in a yaml file) to the in-memory instantiated objects
@@ -62,7 +62,7 @@ particular hardware might look like:
           addr: "od90"
           integrations: 500
 
-The object under ``hardware.temp`` is recognized in the evolver system as a
+The object under ``hardware.temp`` is recognized in the eVOLVER system as a
 ``ConfigDescriptor``, where the object to create is an
 ``evolver.hardware.standard.od_sensor.ODSensor`` and the config to pass in will
 be an evaluated version of its ``Config``. To clarify the point, consider the
@@ -82,7 +82,7 @@ the ``Config`` class represented within the ``config`` key.
 Experiment loop
 ---------------
 
-In the normal mode, the evolver operates in a loop, continuously performing the
+In the normal mode, the eVOLVER operates in a loop, continuously performing the
 following steps in succession:
 
 1. **Read sensors**: values are `read` and buffered within individual hardware
@@ -113,13 +113,13 @@ the loop.
 Buffering
 ---------
 
-Both Sensor and Effector drivers in the evolver system have separate methods for
+Both Sensor and Effector drivers in the eVOLVER system have separate methods for
 reading/writing values to the underlying hardware device and for getting and
-setting values in within the evolver software framework.
+setting values in within the eVOLVER software framework.
 
 The primary reason for this separation is to simplify the operation of
 potentially multiple controllers working against multiple vials, while
-recognizing that the serial protocol for hardware on the standard evolver boxes
+recognizing that the serial protocol for hardware on the standard eVOLVER boxes
 both:
 
 * reads-to/writes-from *all* vials in a single serial communication, and
@@ -148,7 +148,7 @@ of configured vials.
 
 .. note::
   Note that values are typically neither read nor committed within the `control`
-  method itself - these are executed by the evolver in the **read** and
+  method itself - these are executed by the eVOLVER in the **read** and
   **commit** phases of :ref:`experiment_loop`. Multiple ``get`` calls would
   return the same values and subsequent ``set`` calls would overwrite the value
   to commit.

--- a/docs/source/development/config.rst
+++ b/docs/source/development/config.rst
@@ -56,7 +56,7 @@ the wire via the web API.
 
 In the serialized configuration, we describe a component by its class and the
 data members to set on its config. This is done via a
-:py:class:`ConfigDescriptor<evolver.config.ConfigDescriptor>`. For example, the
+:py:class:`ConfigDescriptor<evolver.base.ConfigDescriptor>`. For example, the
 above `MyController` class can be described in the serialized configuration as
 follows (assuming it is defined in `my_module`)::
 
@@ -68,7 +68,7 @@ follows (assuming it is defined in `my_module`)::
 JSON schema
 -----------
 
-The web API also provides and endpoint to retreive the JSON schema for the
+The web API also provides and endpoint to retrieve the JSON schema for the
 configuration of a particular component by its fully qualified class name::
 
     GET /schema/?classinfo={component_name}
@@ -121,6 +121,22 @@ might return something like:
 
 which contains enough information to generate a UI form for the component's
 configuration.
+
+The base of the configuration for the eVOLVER application is defined in the
+`Config` of :py:class:`Evolver<evolver.device.Evolver>`, so to get the schema for
+the base configuration you can use::
+
+    GET /schema/?classinfo=evolver.device.Evolver
+
+This is the schema of what will be deserialized from yaml when the eVOLVER
+application starts up. The schema of any dynamically configured component within
+can be inspected as above.
+
+In the python interpreter, you can access the schema of any config component by
+calling pydantics `model_json_schema()` on the class::
+
+    from evolver.device import Evolver
+    schema = Evolver.Config.model_json_schema()
 
 Component initialization and configuration
 ------------------------------------------

--- a/docs/source/development/config.rst
+++ b/docs/source/development/config.rst
@@ -76,7 +76,8 @@ configuration of a particular component by its fully qualified class name::
 
 might return something like:
 
-.. json::
+.. code-block:: json
+
     {
         "classinfo": "my_module.MyController",
         "config": {

--- a/docs/source/development/config.rst
+++ b/docs/source/development/config.rst
@@ -122,5 +122,34 @@ might return something like:
 which contains enough information to generate a UI form for the component's
 configuration.
 
-Config and component initialization
------------------------------------
+Component initialization and configuration
+------------------------------------------
+
+When a component is initialized via a config descriptor (e.g. when reading the
+configuration file on startup or via the web update API - specifically by
+calling :py:meth:`create<evolver.base.ConfigDescriptor.create>` on config
+descriptor or :py:meth:`create` on the base interface), by default the members
+of its `config` are unpacked and passed to the components constructor. Then the
+base class for components
+(:py:class:`BaseInterface<evolver.base.BaseInterface>`) will automatically
+assign the config members to the component instance as attributes.
+
+This effectively means that parameters in the config are also class parameters
+and can be directly accessed and used within the component logic. In the example
+above, this means that the control code in `MyController` could access
+`self.param_required`, as in::
+
+    class MyController(Controller):
+        <<<...>>>
+        def control(self):
+            if self.param_required > 0:
+                # do something based on the required parameter
+                <<<...>>>
+
+.. warning::
+    This has an implication on the mutability of the class parameters that share
+    a name with the config members: due to the serializability requirements of
+    components, such members should also be serializable and compatible with the
+    config model. For example, if `param` has a type hint of `float` in the config
+    model, then setting `self.param = "string"` will violate the type validation
+    on serialization and may cause errors in the application.

--- a/docs/source/development/config.rst
+++ b/docs/source/development/config.rst
@@ -1,4 +1,125 @@
 Config
 ======
 
-TBD
+Each pluggable component within the eVOLVER system is defined as a python class
+which itself contains a `Config` class that defines optional and required data
+affecting the behavior of the component that is used for serialization,
+deserialization, and UI form creation (see also :ref:`config`).
+
+The config class
+----------------
+
+The config classes are based on [pydantic](https://docs.pydantic.dev/latest/)
+models which leverage type annotations on class data members to define the data
+schema.
+
+As an example, consider the following abbreviated definition of a controller
+class, which is a pluggable component in the eVOLVER system::
+
+    class MyController(Controller):
+        class Config(Controller.Config):
+            param_required: float
+            param_optional: int = 10  # has a default value
+            param_optional_with_desc: str = Field(default="default", description="A string parameter")
+
+You can observe several things here:
+
+* The `Config` class is a nested class within the component class, which is a
+  common pattern in eVOLVER components. This is a convenience that keeps the
+  definition clearly in the context in which it is used, and enables the system
+  to access the config as a standard-defined class attribute (i.e.
+  `MyController.Config`).
+* The `Config` class inherits from the parent component's `Config` class, which
+  allows it to extend the configuration with additional parameters while still
+  inheriting the base configuration.
+* The data members of the `Config` class are defined with type annotations. This
+  is a requirement from pydantic that enables it to both validate the data,
+  reliably perform serialization, and generate a json-schema that con be used to
+  dynamically generate UI forms.
+* The `Field` function can be used to provide additional metadata about the
+  particular field such as a description and validation rules (see
+  https://docs.pydantic.dev/latest/api/fields/#pydantic.fields.Field)
+
+
+Note that while the eVOLVER system adds additional functionality - such as
+from-file loading and automatic handling of eVOLVER components defined in the
+config - pydantic does most of the heavy lifting here, so see its documentation
+for information on how to apply custom validations or otherwise extend the
+config models.
+
+Serialized configuration
+------------------------
+
+The config classes described above are what enable the eVOLVER system to be
+described within a static yaml file (e.g. `evolver.yml`), and be configured over
+the wire via the web API.
+
+In the serialized configuration, we describe a component by its class and the
+data members to set on its config. This is done via a
+:py:class:`ConfigDescriptor<evolver.config.ConfigDescriptor>`. For example, the
+above `MyController` class can be described in the serialized configuration as
+follows (assuming it is defined in `my_module`)::
+
+        classinfo: "my_module.MyController"
+        config:
+          param_required: 3.14
+          param_optional_with_desc: "Hello, world!"
+
+JSON schema
+-----------
+
+The web API also provides and endpoint to retreive the JSON schema for the
+configuration of a particular component by its fully qualified class name::
+
+    GET /schema/?classinfo={component_name}
+
+
+might return something like:
+
+.. json::
+    {
+        "classinfo": "my_module.MyController",
+        "config": {
+            "properties": {
+                "name": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "type": "null"
+                        }
+                    ],
+                    "default": null,
+                    "title": "Name"
+                },
+                "param_required": {
+                    "title": "Param Required",
+                    "type": "number"
+                },
+                "param_optional": {
+                    "default": 10,
+                    "title": "Param Optional",
+                    "type": "integer"
+                },
+                "param_optional_with_desc": {
+                    "default": "default",
+                    "description": "A string parameter",
+                    "title": "Param Optional With Desc",
+                    "type": "string"
+                }
+            },
+            "required": [
+                "param_required"
+            ],
+            "title": "Config",
+            "type": "object"
+        }
+    }
+
+
+which contains enough information to generate a UI form for the component's
+configuration.
+
+Config and component initialization
+-----------------------------------

--- a/docs/source/development/controllers.rst
+++ b/docs/source/development/controllers.rst
@@ -2,8 +2,8 @@ Developing a new controller
 ===========================
 
 In eVolver, controllers are the components that implement experiment logic. They
-can read the state and history of the eVolver environment (e.g. the sensor
-values) and subsequently modify it (via effectors). In a typical eVolver setup
+can read the state and history of the eVOLVER environment (e.g. the sensor
+values) and subsequently modify it (via effectors). In a typical eVOLVER setup
 controller logic is executed once during a device loop, after reading the state
 of all sensors. See :doc:`/concepts` for more details on the device operation.
 
@@ -25,7 +25,7 @@ input).
     operation - and in particular the differences between getting and reading
     sensors and setting and committing effectors - see :doc:`/concepts`.
 
-As with other eVolver components, controllers contain `Config` classes that
+As with other eVOLVER components, controllers contain `Config` classes that
 define the configuration options for the experiment, which can be read from
 on-disk config and modified via the API and UIs. Authors should provide a
 `Config` class that inherits from :class:`evolver.controller.Controller.Config`
@@ -67,7 +67,7 @@ set desired state.
 .. note::
 
     The `evolver` property comes from hookup to the device (which happens for
-    example in creating a new eVolver from configuration), see also
+    example in creating a new eVOLVER from configuration), see also
     :ref:`evolver-hookup` below. `vials` comes from the base controller `Config`
     class, and represents a list of vials to operate on.
 
@@ -83,7 +83,7 @@ You might note in the above example that:
 The concept here is that each instance of a controller is a specific instance of
 the experiment on a set of vials. In the simplest case one experiment with a
 given set of configuration parameters is run on all vials on the box. The
-eVolver accepts a list of controllers, which can represent either distinct
+eVOLVER accepts a list of controllers, which can represent either distinct
 experiment logic on separate vials, or distinctly configured instances of the
 same experiment on separate vials. Their ``control`` methods are run in order
 during the control loop (wee :doc:`/concepts` for more details on experiment
@@ -114,19 +114,19 @@ Because the controller's main function is to modify the environment based on
 inputs, we can test a controller by mocking the hardware dependencies and
 asserting expected outputs are sent to particular hardware.
 
-We are currently working on a testing framework for eVolver controllers (please
+We are currently working on a testing framework for eVOLVER controllers (please
 see https://github.com/ssec-jhu/evolver-ng/issues/156), but in the meantime, an
-example for mocking hardware within an eVolver environment can be seen in the
-`test_chemostat.py` file in the eVolver repository.
+example for mocking hardware within an eVOLVER environment can be seen in the
+`test_chemostat.py` file in the eVOLVER repository.
 
 
 Logging in the controller
 -------------------------
 
-All components in the eVolver framework contain an internal logger which is an
+All components in the eVOLVER framework contain an internal logger which is an
 instance of a python standard library `logging.Logger`. This logger can be used
 to emit messages from within a controller which, unless otherwise configured,
-will get routed through the eVolver logging mechanism.
+will get routed through the eVOLVER logging mechanism.
 
 .. note::
 
@@ -154,7 +154,7 @@ given sensor in memory within the controller, this may have unintended
 consequences in the case of reboot or even a reconfiguration of the eVolver
 (which reallocates all objects): the buffer would be lost.
 
-eVolver provides a history server which is backed by persistent storage designed
+eVOLVER provides a history server which is backed by persistent storage designed
 to be queried via the API or within a controller. This means controller code
 can remain simple and focus on core logic, as opposed to maintaining file-based
 historic data or error-prone in-memory buffers.
@@ -183,7 +183,7 @@ For example::
 
 .. _evolver-hookup:
 
-Evolver hookup and portability
+eVOLVER hookup and portability
 ------------------------------
 
 You might notice that the controller in the example above implicitly requires an
@@ -211,10 +211,10 @@ hardware class, then a property which dispatches appropriately, for example::
 In the above case, when the controller operates within the application, the
 temp_sensor will be specified as the name of the hardware in the eVolver
 configuration file, and the controller will use the hardware instance from the
-eVolver.
+eVOLVER.
 
 If the controller should be instantiated outside the framework (and without an
-evolver instance), the instantiated Temperature object can be passed in
+eVOLVER instance), the instantiated Temperature object can be passed in
 directly::
 
     temp_sensor = Temperature()

--- a/docs/source/development/hardware.rst
+++ b/docs/source/development/hardware.rst
@@ -4,7 +4,7 @@ Developing custom hardware drivers
 Basics
 ------
 
-Implementing hardware within the eVolver system means creating a new subclass of
+Implementing hardware within the eVOLVER system means creating a new subclass of
 the appropriate driver interface classes, creating concrete implementations of
 the abstract methods therein.
 
@@ -52,9 +52,9 @@ Using the built-in serial interface
 -----------------------------------
 
 Many drivers will want to use the shared serial bus attached to a standard
-eVolver setup, addressing a specific component on that line. Since this is a
+eVOLVER setup, addressing a specific component on that line. Since this is a
 shared global resource that must be locked to avoid contention, it is defined at
-the main eVolver level. When the eVolver manager constructs hardware drivers, it
+the main eVOLVER level. When the eVOLVER manager constructs hardware drivers, it
 passes itself in as the `evolver` attribute to the driver constructor, in a
 manner similar to::
 

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -1,4 +1,4 @@
-Developing eVolver components
+Developing eVOLVER components
 =============================
 
 .. toctree::

--- a/docs/source/development/index.rst
+++ b/docs/source/development/index.rst
@@ -6,3 +6,4 @@ Developing eVOLVER components
     controllers
     hardware
     calibrators
+    installation

--- a/docs/source/development/installation.rst
+++ b/docs/source/development/installation.rst
@@ -1,0 +1,34 @@
+Installing custom components
+============================
+
+Custom components are defined in python modules and can be installed via
+standard python packaging tools such as pip. Generally these modules must be
+installed onto the Raspberry Pi running the eVOLVER server, as they will be
+loaded upon deserialization of the configuration file which references them.
+
+For example, if you have a custom hardware driver defined in a python module
+named `my_custom_hardware` within a public github repository, you can install it
+using pip like so::
+
+    # ssh into the Raspberry Pi running the eVOLVER server
+    ssh pi@<evolver-ip-address>
+
+    # then install the custom hardware package
+    pip install --upgrade git+https://github.com/username/my-custom-hardware-package.git
+
+Then, you can reference this custom hardware in your configuration file by using
+its fully qualified class name (assuming you have defined a class implementing
+a `SensorDriver` defined in the `my_custom_hardware.py` module), such as::
+
+    hardware:
+      MyCustomSensor:
+        classinfo: "my_custom_hardware.MyCustomSensorDriver"
+        config:
+          addr: "custom_sensor_address"
+          integrations: 1000
+
+
+For more details on packaging and distribution of python components, see
+https://packaging.python.org/en/latest/. This repository also serves as an
+example of python packaging, and can be similarly installed via pip and git as
+described above.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,23 +1,29 @@
-eVolver-ng: The next generation eVolver control plane
+evolver-ng: The next generation eVOLVER control plane
 =====================================================
 
 This package provides a server application and interface specification for
-remote configuration and control of eVolver systems. The system is designed to
+remote configuration and control of eVOLVER systems. The system is designed to
 be fully specified by a single configuration file, run without intervention for
 long-running experiment durations, provide a well-defined web-API for remote
 applications to design against, and be extended with new hardware and control
 codes using a simple plugin system.
 
 Check out the :doc:`quick-start` for if you want to get a feel for the system
-without requiring installation on the eVolver hardware. If you are ready to
-install the system on your eVolver hardware, check out the :doc:`installation`
-documentation. If you have an eVolver ready to go, see :doc:`usage` for how to
+without requiring installation on the eVOLVER hardware. If you are ready to
+install the system on your eVOLVER hardware, check out the :doc:`installation`
+documentation. If you have an eVOLVER ready to go, see :doc:`usage` for how to
 get an experiment running on the hardware. Finally, if you would like to extend
 by developing control codes or hardware drivers, see :doc:`development/index`.
 
 .. note::
 
    This project is under active development.
+
+.. note::
+
+   In this guide we refer the the physical eVOLVER as a system or concept as
+   "eVOLVER" (noting case) and to the software package components as "evolver"
+   (the python module) or "evolver-ng" (the repository).
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -88,7 +88,7 @@ end-users. See :doc:`development/index` for more information on creating
 extensions.
 
 Web UI
-~~~~~~
+------
 
 We can similarly install the web UI on the Raspberry Pi, or any other computer
 with network access to one or more evolver servers.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,7 +5,7 @@ Server
 ------
 
 This guide is for installing the server on the Raspberry Pi mounted within the
-eVolver hardware platform connected via serial to the physical hardware (see
+eVOLVER hardware platform connected via serial to the physical hardware (see
 :doc:`quick-start` for running the server locally with dummy hardware).
 
 Requirements
@@ -16,7 +16,7 @@ is up to date and has at least this version of python installed. We recommend
 using the debian based systems, such as bookworm
 (see https://www.raspberrypi.com/software/operating-systems/).
 
-If you are using the standard eVolver hardware, the Raspberry Pi should also be
+If you are using the standard eVOLVER hardware, the Raspberry Pi should also be
 setup to use the UART serial port available at ttyAMA0, which requires custom
 bootflags in order to disable bluetooth and enable the serial port. This can be
 done by adding the following to the /boot/firmware/config.txt file::
@@ -57,7 +57,7 @@ interface at http://<raspberry-pi-ip>:8080/docs.
 Configuration
 ~~~~~~~~~~~~~
 
-The evolver server needs to be configured with the hardware drivers that are
+The eVOLVER server needs to be configured with the hardware drivers that are
 available on the system. This can be done either by creating or obtaining the
 appropriate configuration file prior to server start. Alternatively the API/UI
 can be used to update the configuration for a server that is already online.
@@ -91,7 +91,7 @@ Web UI
 ------
 
 We can similarly install the web UI on the Raspberry Pi, or any other computer
-with network access to one or more evolver servers.
+with network access to one or more eVOLVER servers.
 
 The simplest way to install the web UI is to use mise to install npm, then build
 the and run the service via npm.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,12 +1,15 @@
 Installation
 ============
 
+Server
+------
+
 This guide is for installing the server on the Raspberry Pi mounted within the
 eVolver hardware platform connected via serial to the physical hardware (see
 :doc:`quick-start` for running the server locally with dummy hardware).
 
 Requirements
-------------
+~~~~~~~~~~~~
 
 The application depends on python 3.11 or later, so ensure the Raspberry Pi os
 is up to date and has at least this version of python installed. We recommend
@@ -23,7 +26,7 @@ done by adding the following to the /boot/firmware/config.txt file::
     dtoverlay=pi3-disable-bt
 
 Install and setup service
--------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 * Install the package::
 
@@ -52,7 +55,7 @@ connections. You can confirm this by navigating to the openapi documentation
 interface at http://<raspberry-pi-ip>:8080/docs.
 
 Configuration
--------------
+~~~~~~~~~~~~~
 
 The evolver server needs to be configured with the hardware drivers that are
 available on the system. This can be done either by creating or obtaining the
@@ -84,4 +87,65 @@ installing the package, and example configurations to simplify setup for
 end-users. See :doc:`development/index` for more information on creating
 extensions.
 
+Web UI
+~~~~~~
 
+We can similarly install the web UI on the Raspberry Pi, or any other computer
+with network access to one or more evolver servers.
+
+The simplest way to install the web UI is to use mise to install npm, then build
+the and run the service via npm.
+
+* install mise (see also https://mise.jdx.dev/getting-started.html)::
+
+    curl https://mise.run | sh
+
+* install npm via mise::
+
+    mise use node@lts
+
+* clone the web UI repository::
+
+    git clone https://github.com/ssec-jhu/evolver-ui
+
+* build it::
+
+    cd evolver-ui
+    npm install
+    npm run build
+
+* run it::
+
+    npm run server
+
+Install and setup service
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+We can also setup the web UI to run as a service on the Raspberry Pi. Here is an
+example systemd service file (for example at `/etc/systemd/system/evolver-ui.service`)::
+
+  [Service]
+  Requires=evolver.service
+  ExecStart=/home/pi/evolver-ui/start-ui.sh
+  WorkingDirectory=/home/pi/evolver-ui
+  Restart=on-failure
+  Type=exec
+
+  [Install]
+  WantedBy=multi-user.target
+
+The above uses a helper script to start the UI that has been placed at the root
+of the repository::
+
+  #!/bin/sh
+  export PATH=/home/pi/.local/share/mise/installs/node/22.15.0/bin:${PATH}
+  cd /home/pi/evolver-ui
+  npm start
+
+After which you can enable and start the service::
+
+    sudo systemctl enable evolver-ui
+    sudo systemctl start evolver-ui
+
+By default the UI will run on port 3000, so navigate your browser there and add
+devices as necessary.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -116,7 +116,7 @@ the and run the service via npm.
 
 * run it::
 
-    npm run server
+    npm run start
 
 Install and setup service
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -94,7 +94,8 @@ We can similarly install the web UI on the Raspberry Pi, or any other computer
 with network access to one or more eVOLVER servers.
 
 The simplest way to install the web UI is to use mise to install npm, then build
-the and run the service via npm.
+the and run the service via npm (see also
+https://github.com/ssec-jhu/evolver-ui).
 
 * install mise (see also https://mise.jdx.dev/getting-started.html)::
 

--- a/docs/source/quick-start.rst
+++ b/docs/source/quick-start.rst
@@ -1,8 +1,8 @@
 Quick Start
 ===========
 
-While the eVolver server is meant to run on the Raspberry Pi mounted within the
-eVolver hardware platform connected via serial to the physical hardware, it is
+While the eVOLVER server is meant to run on the Raspberry Pi mounted within the
+eVOLVER hardware platform connected via serial to the physical hardware, it is
 sometimes desireable to run it locally using dummy hardware for evaluation of
 configuration or api calls.
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -16,7 +16,7 @@ either the web interface or via the http API:
 Applying configuration
 -----------------------
 
-The eVolver server is self-contained and described by a static configuration
+The eVOLVER server is self-contained and described by a static configuration
 containing the physical setup and experiment control logic. This allows it to
 run experiments without intervention for long periods of time, and withstand
 failure and restarts, losing only the down-time interval.
@@ -36,11 +36,11 @@ Likewise it can be downloaded for editing and re-upload using a GET request::
 Configuring the hardware
 -------------------------
 
-Since the hardware portion of the eVolver is directly related to the physical
-setup of the evolver box, configuration should often be obtained from the source
+Since the hardware portion of the eVOLVER is directly related to the physical
+setup of the eVOLVER box, configuration should often be obtained from the source
 of the hardware or from examples for modular hardware components shared by their
 creators. The evolver-ng package will contain such examples for hardware
-components built or maintained by the eVolver team.
+components built or maintained by the eVOLVER team.
 
 As with all configuration in the system, each component will have a class
 specifying the code component that controls it, along with a configuration
@@ -101,7 +101,7 @@ Configure experiments
 =====================
 
 Experiments are configured in the same manner as other components in the system,
-such as hardware described above. The eVolver has a set of named experiments,
+such as hardware described above. The eVOLVER has a set of named experiments,
 which in turn are made up of one or more
 :py:class:`Controllers<evolver.controller.interface.Controller>`. Each
 controller is a descriptor object that has a config section, for example:
@@ -152,7 +152,7 @@ data.
 Aborting
 ========
 
-In general, once started, the eVolver will continuously run the experiment loop
+In general, once started, the eVOLVER will continuously run the experiment loop
 (see :ref:`experiment_loop`) until stopped. When there are experiments
 configured on the system, this means that physical actuation of some devices on
 the system may be carried out, and in cases where feedback about certain


### PR DESCRIPTION
This PR addresses the below feedback (from slack) in a way I think fits with the package:

> * use "eVOLVER" spelling to maintain consistency (outside of code blocks)

✅ also added a note with disambiguation of use through the docs

> * the config section is still blank but when its populated i think it would useful to show an example of a valid config and the values each attribute expects
> * a page/section dedicated to explaining the core data validation models

^ The first is addressed in the config section pointing to its generic nature and the json schema endpoint/methods, the config class pattern, and the relevant definitions for the application. The second one is addressed in the same config section pointing to its pydantic base and example field definitions.

> * when describing how to develop custom eVOLVER components, should also include how to explicitly integrate into the system. can be as simple as "ssh x into y directory" but i having it documented ensures that people are putting custom things in the right places so that when the config is edited to incorporate there arent any issues

^ added in an installation page under the development section to discuss how to get custom components available on the system.

> * in the installation page include a page for the UI (most people will be interfacing with the config through the UI so i think having a basic installation guide for it is useful here)

^ Included a section for the UI installation and service definition on the rPi - with a pointer to the UI repo